### PR TITLE
fix(ci): remove component prefix from operator release tags for proper semver tagging

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -7,6 +7,7 @@
       "package-name": "keycloak-operator",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "include-component-in-tag": false,
       "changelog-sections": [
         {"type": "feat", "section": "Features", "hidden": false},
         {"type": "fix", "section": "Bug Fixes", "hidden": false},

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,8 @@ on:
   push:
     branches: [main, develop]
     tags:
-      - 'operator-v*'
+      - 'v*'
+      - 'operator-v*'  # Legacy format for backward compatibility
       - 'chart-*-v*'
   pull_request:
     branches: [main, develop]
@@ -525,6 +526,9 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=short,enable={{is_default_branch}}
+            type=match,pattern=operator-v(.*),group=1
+            type=match,pattern=operator-v(\d+\.\d+),group=1
+            type=match,pattern=operator-v(\d+),group=1,enable=${{ !startsWith(github.ref, 'refs/tags/operator-v0.') }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -55,7 +55,7 @@ The repository contains four independently versioned components:
 ### 1. Operator (Docker Image)
 - **Path**: Root directory (`.`)
 - **Artifact**: Docker image at `ghcr.io/vriesdemichael/keycloak-operator`
-- **Release Tags**: `v1.2.3` (no component prefix)
+- **Release Tags**: `v1.2.3` (semver format without component prefix)
 - **Triggered by**: Any conventional commit **without** chart scope
 
 ### 2. Keycloak Operator Helm Chart


### PR DESCRIPTION
## Problem
The operator Docker images were being published with only SHA tags (e.g., `sha-73101d5`) instead of semver tags (e.g., `v0.2.7`, `0.2.7`, `0.2`, `0`).

## Root Cause
Release-please was creating tags with the `operator-` prefix (e.g., `operator-v0.2.6`) instead of plain semver format (e.g., `v0.2.6`). The `docker/metadata-action` semver patterns in the CI/CD workflow require tags without component prefixes to properly generate version tags.

## Solution
1. Set `include-component-in-tag: false` for the operator component in `.github/release-please-config.json`
2. Update CI/CD workflow to accept both `v*` and `operator-v*` tags for backward compatibility
3. Clarify tag format in `RELEASES.md` documentation

## Expected Behavior After Fix
Future operator releases will:
- Be tagged as `v0.2.8`, `v0.2.9`, etc. (without `operator-` prefix)
- Generate proper Docker image tags:
  - `ghcr.io/vriesdemichael/keycloak-operator:v0.2.8`
  - `ghcr.io/vriesdemichael/keycloak-operator:0.2.8`
  - `ghcr.io/vriesdemichael/keycloak-operator:0.2`
  - `ghcr.io/vriesdemichael/keycloak-operator:0`
  - `ghcr.io/vriesdemichael/keycloak-operator:latest`
  - `ghcr.io/vriesdemichael/keycloak-operator:sha-<commit>`

## Backward Compatibility
The CI/CD workflow still accepts legacy `operator-v*` tags to ensure old tags continue to work.

## Verification
After this PR is merged and the next operator release is created, verify:
1. Tag format is `v0.2.8` (not `operator-v0.2.8`)
2. Docker images include semver tags in addition to SHA tags
3. Helm charts continue to use their existing tag format (`chart-*-v*`)