### PR TITLE
docs: add scaling strategy documentation to architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,106 @@ This operator is structured into clear layers to keep reconciliation logic maint
 
 Custom exceptions in `errors/operator_errors.py` categorize recoverable vs fatal failures. Handlers catch and translate them to appropriate Kubernetes events/logs.
 
+## Scaling Strategy
+
+When considering scaling in a Keycloak deployment managed by this operator, it's critical to understand that there are **two distinct types of scaling**, each serving different purposes and having different performance characteristics.
+
+### Two Types of Scaling
+
+#### 1. Operator Scaling (Reconciliation)
+
+The operator itself performs reconciliation actions:
+- Watches Keycloak custom resources
+- Reconciles desired state with actual state
+- Makes Admin API calls to configure Keycloak
+- Manages Kubernetes resources
+
+**Key Point:** Operator scaling is rarely the bottleneck.
+
+#### 2. Keycloak Instance Scaling (End-User Traffic)
+
+The Keycloak instance handles:
+- End-user authentication and authorization requests
+- Session management
+- Token generation and validation
+- User database queries
+- Admin API calls (triggered by operator or administrators)
+
+**Key Point:** This is where you will hit performance limits first.
+
+### Where Bottlenecks Occur
+
+In virtually all real-world scenarios, **you will hit Keycloak instance limitations before operator limitations**, even after vertically scaling both components to their maximum capacity.
+
+The operator's workload (reconciliation loops and occasional Admin API calls) is minimal compared to the Keycloak instance's workload (continuous authentication/authorization requests from thousands or millions of end users).
+
+### When to Scale What
+
+If you're experiencing performance issues:
+
+1. **First, scale the Keycloak instance itself:**
+   - Increase replicas for horizontal scaling
+   - Add database read replicas
+   - Optimize caching configuration
+   - Review realm and client configuration for performance
+
+2. **Only consider operator scaling if:**
+   - You have an extremely high rate of realm/client configuration changes
+   - Reconciliation loops are measurably slow
+   - You can verify that the operator is the actual bottleneck (use metrics/profiling)
+
+### Multi-Operator Deployment Pattern
+
+If you genuinely need more operator capacity (or want to isolate workloads), this operator supports running multiple instances side-by-side in the same cluster.
+
+Each realm can target a specific operator instance using the `operatorRef` field. This allows you to:
+
+- Distribute realm management across multiple operators
+- Isolate different teams or environments to different operators
+- Scale operator capacity horizontally when needed
+
+**Example configuration:**
+
+```yaml
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealm
+metadata:
+  name: my-realm
+spec:
+  operatorRef: operator-2  # Target specific operator instance
+  # ... rest of realm config
+```
+
+**When to use multiple operators:**
+
+- Large number of realms with frequent configuration changes
+- Workload isolation (e.g., production vs non-production)
+- Geographic distribution across regions/clusters
+- Huge monolithic realms that cannot be subdivided
+
+**When NOT to use multiple operators:**
+
+- To improve end-user authentication performance (scale Keycloak instead)
+- As a first resort (vertical scaling is usually sufficient)
+- Without measuring (verify the operator is actually your bottleneck)
+
+### Recommended Approach
+
+For most use cases:
+
+1. Start with a single operator instance with reasonable resource limits
+2. Scale your Keycloak instances to meet end-user authentication demands
+3. Monitor operator performance using available metrics
+4. Only deploy additional operators when you can demonstrate that reconciliation performance is actually limiting your operations
+
+### Common Misconception
+
+> "Python operators don't scale as well as Go operators, so I need multiple instances."
+
+**Reality:** For this workload, the language choice has minimal impact. The operator spends most of its time waiting for Kubernetes API responses and Keycloak Admin API calls, not doing CPU-intensive work. A single Python-based operator can easily manage dozens of realms without performance degradation.
+
+The scaling strategy should be driven by **actual performance metrics and requirements**, not by assumptions about implementation language.
+
 ## Future Enhancements
 
 - Finalizers for deterministic teardown


### PR DESCRIPTION
## Description

Addresses #45 by documenting the scaling strategy for this operator.

## Changes

- Added comprehensive scaling strategy section to `docs/architecture.md`
- Clarifies the two types of scaling:
  1. **Operator scaling** (reconciliation) - rarely the bottleneck
  2. **Keycloak instance scaling** (end-user traffic) - the actual bottleneck
- Documents the multi-operator deployment pattern using `operatorRef`
- Addresses common misconception about Python vs Go operator performance

## Key Points

- Keycloak instance scaling should always be prioritized over operator scaling
- Multi-operator deployment is supported but should be used judiciously
- Language choice (Python vs Go) has minimal performance impact for this workload

Closes #45