### PR TITLE
ci(operator): refactor release workflow to build-once promote-on-release pattern

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "component": "operator",
+      "component": "Operator Image",
       "package-name": "keycloak-operator",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,17 +10,9 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [main, develop]
-    tags:
-      - 'v*'
-      - 'operator-v*'  # Legacy format for backward compatibility
-      - 'chart-*-v*'
   pull_request:
     branches: [main, develop]
-  release:
-    types: [published]
   workflow_dispatch:
-  repository_dispatch:
-    types: [release-published]
 
 env:
   REGISTRY: ghcr.io
@@ -497,39 +489,30 @@ jobs:
           retention-days: 7
 
   # ==========================================================================
-  # STAGE 4: BUILD & PUBLISH
-  # Build production images and publish to registry
+  # STAGE 4: PUBLISH SHA IMAGE
+  # Push tested operator image with sha-{commit} tag to registry
   # Only runs on main branch after all tests pass
+  # Version tags (v0.2.16, latest) are added by promote-operator workflow
   # ==========================================================================
 
-  publish:
-    name: Build & Publish Production Images
+  push-sha-image:
+    name: Push SHA-Tagged Image
     needs: [integration-tests]
-    if: |
-      (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
-      github.event_name == 'release' ||
-      github.event_name == 'repository_dispatch' ||
-      startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
 
     permissions:
       contents: read
       packages: write
-      id-token: write
       security-events: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: |
-            image=moby/buildkit:latest
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -538,54 +521,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine version tag
-        id: version
-        env:
-          GITHUB_REF: ${{ github.ref }}
-        run: |
-          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
-            # Extract tag from repository_dispatch payload
-            TAG="${{ github.event.client_payload.tag }}"
-            if [ -n "$TAG" ]; then
-              echo "version_tag=${TAG}" >> $GITHUB_OUTPUT
-              echo "is_release=true" >> $GITHUB_OUTPUT
-              echo "Using tag from dispatch payload: ${TAG}"
-            else
-              echo "version_tag=" >> $GITHUB_OUTPUT
-              echo "is_release=false" >> $GITHUB_OUTPUT
-              echo "No tag in payload"
-            fi
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            # Extract tag from git ref
-            TAG="${GITHUB_REF#refs/tags/}"
-            echo "version_tag=${TAG}" >> $GITHUB_OUTPUT
-            echo "is_release=true" >> $GITHUB_OUTPUT
-            echo "Using tag from git ref: ${TAG}"
-          else
-            echo "version_tag=" >> $GITHUB_OUTPUT
-            echo "is_release=false" >> $GITHUB_OUTPUT
-            echo "Not a release build"
-          fi
-
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata for SHA tag
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=sha-,format=short,enable={{is_default_branch}}
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=raw,value=${{ steps.version.outputs.version_tag }},enable=${{ steps.version.outputs.is_release == 'true' }}
+            type=sha,prefix=sha-,format=short
           labels: |
             org.opencontainers.image.title=Keycloak Operator
             org.opencontainers.image.description=GitOps-compatible Kubernetes operator for Keycloak
             org.opencontainers.image.vendor=Michaël de Vries
             org.opencontainers.image.licenses=MIT
-            org.opencontainers.image.version=${{ steps.version.outputs.version_tag }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -601,18 +548,24 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
 
+      - name: Get image reference
+        id: image
+        run: |
+          IMAGE_TAG="${{ steps.meta.outputs.tags }}"
+          echo "ref=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "Published image: ${IMAGE_TAG}"
+
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          image: ${{ steps.image.outputs.ref }}
           format: spdx-json
           output-file: sbom.spdx.json
-          upload-artifact: true
 
       - name: Scan published image with Trivy
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          image-ref: ${{ steps.image.outputs.ref }}
           format: 'sarif'
           output: 'trivy-published-results.sarif'
           severity: 'CRITICAL,HIGH'
@@ -622,7 +575,7 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-published-results.sarif'
-          category: 'trivy-published-image'
+          category: 'trivy-sha-image'
 
       - name: Scan SBOM for vulnerabilities
         uses: anchore/scan-action@v7
@@ -631,19 +584,25 @@ jobs:
           fail-build: true
           severity-cutoff: critical
 
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: sbom-sha-image
+          path: sbom.spdx.json
+          retention-days: 90
+
       - name: Summary
         run: |
-          echo "### :whale: Docker Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "### :whale: SHA-Tagged Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Registry:** \`${{ env.REGISTRY }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Repository:** \`${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ steps.image.outputs.ref }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "This image has been tested and is ready for promotion." >> $GITHUB_STEP_SUMMARY
+          echo "Version tags will be added when a release is created." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Pull command:**" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ steps.image.outputs.ref }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/promote-operator.yml
+++ b/.github/workflows/promote-operator.yml
@@ -1,0 +1,139 @@
+name: Promote Operator Image
+
+# Promote tested operator image with version tags on release
+# Does NOT rebuild - pulls existing sha-{commit} image and re-tags it
+# Only runs for operator releases (v*), not chart releases (chart-*-v*)
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  promote:
+    name: Promote Operator Image
+    # Only promote operator releases (v0.2.16), not chart releases (chart-operator-v0.1.5)
+    if: startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, 'chart-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract commit SHA and construct source image
+        id: source
+        run: |
+          # Get commit SHA for this release tag
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          SOURCE_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${COMMIT_SHA}"
+
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "image=${SOURCE_IMAGE}" >> $GITHUB_OUTPUT
+          echo "Source image: ${SOURCE_IMAGE}"
+
+      - name: Pull source image
+        run: |
+          echo "Pulling tested image: ${{ steps.source.outputs.image }}"
+          docker pull ${{ steps.source.outputs.image }}
+
+      - name: Generate version tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.event.release.tag_name, 'v0.') }}
+          labels: |
+            org.opencontainers.image.title=Keycloak Operator
+            org.opencontainers.image.description=GitOps-compatible Kubernetes operator for Keycloak
+            org.opencontainers.image.vendor=Michaël de Vries
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.version=${{ github.event.release.tag_name }}
+
+      - name: Tag and push version tags
+        run: |
+          SOURCE_IMAGE="${{ steps.source.outputs.image }}"
+
+          # Read tags from metadata-action output (newline-separated)
+          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              echo "Tagging: ${tag}"
+              docker tag "${SOURCE_IMAGE}" "${tag}"
+              docker push "${tag}"
+            fi
+          done
+
+      - name: Generate SBOM for released image
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM to release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} sbom.spdx.json \
+            --clobber \
+            --repo ${{ github.repository }}
+
+      - name: Scan promoted image with Trivy
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          format: 'sarif'
+          output: 'trivy-release-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: 'trivy-release-results.sarif'
+          category: 'trivy-release-image'
+
+      - name: Summary
+        run: |
+          echo "### :rocket: Operator Image Promoted" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Release:** \`${{ github.event.release.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Source Image:** \`${{ steps.source.outputs.image }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**New Tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The tested image from commit \`${{ steps.source.outputs.commit_sha }}\` has been promoted." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Pull command:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "# or" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,17 +31,6 @@ jobs:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 
-      - name: Dispatch CI/CD workflow for release
-        if: steps.release.outputs.release_created == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-        run: |
-          echo "Dispatching CI/CD workflow for tag ${{ steps.release.outputs.tag_name }}"
-          gh api repos/${{ github.repository }}/dispatches \
-            --method POST \
-            --field event_type='release-published' \
-            --field client_payload[tag]='${{ steps.release.outputs.tag_name }}'
-
       - name: Release summary
         if: steps.release.outputs.release_created == 'true'
         run: |
@@ -50,7 +39,11 @@ jobs:
           echo "**Tag:** \`${{ steps.release.outputs.tag_name }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Release URL:** ${{ steps.release.outputs.html_url }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "CI/CD workflow will publish Docker images with semver tags." >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.release.outputs.tag_name }}" == v* && "${{ steps.release.outputs.tag_name }}" != *chart-* ]]; then
+            echo "Promote-operator workflow will tag the tested image with version tags." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Helm chart release - GitHub Pages workflow will publish charts." >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: PR summary
         if: steps.release.outputs.pr != ''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,9 +50,12 @@ repos:
         files: ^charts/keycloak-operator/
         pass_filenames: false
 
-  # Commit message format checking
-  - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.6.0
+  # Commit message format checking with scope validation
+  - repo: local
     hooks:
-      - id: conventional-pre-commit
+      - id: validate-commit-message
+        name: validate commit message
+        entry: uv run python scripts/validate-commit-message.py
+        language: system
         stages: [commit-msg]
+        always_run: true

--- a/scripts/validate-commit-message.py
+++ b/scripts/validate-commit-message.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Validate conventional commit messages with enforced scopes.
+
+This script validates that commit messages follow the conventional commit format
+and use valid scopes from the release-please configuration.
+
+Valid scopes:
+- operator
+- chart-operator
+- chart-realm
+- chart-client
+
+Scopes can be combined with '+' (e.g., 'operator+chart-operator').
+Components must be in alphabetical order and not duplicated.
+
+Examples:
+  ✅ feat(operator): add new feature
+  ✅ fix(chart-realm): fix bug
+  ✅ feat(chart-client+chart-realm): update both charts
+  ✅ chore!: breaking change without scope (allowed)
+  ❌ feat(invalid): wrong scope
+  ❌ feat(operator+operator): duplicate component
+  ❌ feat(chart-realm+chart-client): wrong order (should be chart-client+chart-realm)
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Valid component scopes from release-please-config.json
+VALID_SCOPES = {
+    "operator",
+    "chart-operator",
+    "chart-realm",
+    "chart-client",
+}
+
+# Conventional commit pattern
+# Matches: type(scope): description
+# Optional: ! for breaking changes, scope is optional
+COMMIT_PATTERN = re.compile(
+    r"^(?P<type>feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)"
+    r"(?:\((?P<scope>[^)]+)\))?"
+    r"(?P<breaking>!)?"
+    r": "
+    r"(?P<description>.+)"
+)
+
+
+def validate_scope(scope: str | None) -> tuple[bool, str]:
+    """
+    Validate the scope part of a conventional commit message.
+
+    Args:
+        scope: The scope string (can be None, single scope, or combined scopes with '+')
+
+    Returns:
+        Tuple of (is_valid, error_message)
+    """
+    if scope is None:
+        # Scope is optional for certain commit types
+        return True, ""
+
+    # Split by '+' to get individual components
+    components = scope.split("+")
+
+    # Check for duplicates
+    if len(components) != len(set(components)):
+        duplicates = [c for c in components if components.count(c) > 1]
+        return False, f"Duplicate components in scope: {', '.join(set(duplicates))}"
+
+    # Validate each component
+    invalid_components = [c for c in components if c not in VALID_SCOPES]
+    if invalid_components:
+        return False, (
+            f"Invalid scope components: {', '.join(invalid_components)}\n"
+            f"Valid scopes: {', '.join(sorted(VALID_SCOPES))}"
+        )
+
+    # Check if components are in alphabetical order (for consistency)
+    sorted_components = sorted(components)
+    if components != sorted_components:
+        return False, (
+            f"Scope components must be in alphabetical order.\n"
+            f"Current: {'+'.join(components)}\n"
+            f"Expected: {'+'.join(sorted_components)}"
+        )
+
+    return True, ""
+
+
+def validate_commit_message(message: str) -> tuple[bool, str]:
+    """
+    Validate a conventional commit message.
+
+    Args:
+        message: The commit message to validate
+
+    Returns:
+        Tuple of (is_valid, error_message)
+    """
+    # Get first line of commit message
+    first_line = message.split("\n")[0].strip()
+
+    # Check if it matches conventional commit pattern
+    match = COMMIT_PATTERN.match(first_line)
+    if not match:
+        return False, (
+            "Commit message does not follow conventional commit format.\n"
+            "Expected format: type(scope): description\n"
+            "Valid types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert\n"
+            f"Example: feat(operator): add new feature\n\n"
+            f"Your message: {first_line}"
+        )
+
+    # Validate the scope
+    scope = match.group("scope")
+    scope_valid, scope_error = validate_scope(scope)
+    if not scope_valid:
+        return False, scope_error
+
+    return True, ""
+
+
+def main() -> int:
+    """Main entry point for the commit message validator."""
+    if len(sys.argv) < 2:
+        print("Error: No commit message file provided", file=sys.stderr)
+        return 1
+
+    commit_msg_file = Path(sys.argv[1])
+    if not commit_msg_file.exists():
+        print(
+            f"Error: Commit message file not found: {commit_msg_file}", file=sys.stderr
+        )
+        return 1
+
+    commit_message = commit_msg_file.read_text(encoding="utf-8")
+
+    # Skip validation for merge commits
+    if commit_message.startswith("Merge "):
+        return 0
+
+    # Skip validation for revert commits (they have special format)
+    if commit_message.startswith("Revert "):
+        return 0
+
+    is_valid, error_message = validate_commit_message(commit_message)
+
+    if not is_valid:
+        print("\n❌ Invalid commit message!", file=sys.stderr)
+        print("-" * 60, file=sys.stderr)
+        print(error_message, file=sys.stderr)
+        print("-" * 60, file=sys.stderr)
+        print("\nValid scopes:", file=sys.stderr)
+        for scope in sorted(VALID_SCOPES):
+            print(f"  - {scope}", file=sys.stderr)
+        print(
+            "\nYou can combine scopes with '+' (in alphabetical order):",
+            file=sys.stderr,
+        )
+        print("  - chart-client+chart-realm", file=sys.stderr)
+        print("  - operator+chart-operator", file=sys.stderr)
+        print(
+            "\nScope is optional for chore, docs, ci, and test commits.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_finalizers_e2e.py
+++ b/tests/integration/test_finalizers_e2e.py
@@ -92,7 +92,9 @@ class TestFinalizersE2E:
                         name=realm_name,
                     )
                     finalizers = resource.get("metadata", {}).get("finalizers", [])
-                    return "vriesdemichael.github.io/realm-cleanup" in finalizers
+                    return (
+                        "vriesdemichael.github.io/keycloak-realm-cleanup" in finalizers
+                    )
                 except ApiException:
                     return False
 
@@ -218,7 +220,9 @@ class TestFinalizersE2E:
                         name=client_name,
                     )
                     finalizers = resource.get("metadata", {}).get("finalizers", [])
-                    return "vriesdemichael.github.io/client-cleanup" in finalizers
+                    return (
+                        "vriesdemichael.github.io/keycloak-client-cleanup" in finalizers
+                    )
                 except ApiException:
                     return False
 
@@ -382,7 +386,9 @@ class TestFinalizersE2E:
                     )
                     meta = client.get("metadata", {})
                     finalizers = meta.get("finalizers", [])
-                    return "vriesdemichael.github.io/client-cleanup" in finalizers
+                    return (
+                        "vriesdemichael.github.io/keycloak-client-cleanup" in finalizers
+                    )
                 except ApiException:
                     return False
 

--- a/tests/integration/test_token_bootstrap.py
+++ b/tests/integration/test_token_bootstrap.py
@@ -240,9 +240,13 @@ class TestTokenBootstrap:
             assert owner_ref.name == realm_name
 
             # Verify annotations
-            assert "vriesdemichael.github.io/version" in op_secret.metadata.annotations
             assert (
-                "vriesdemichael.github.io/valid-until" in op_secret.metadata.annotations
+                "vriesdemichael.github.io/keycloak-version"
+                in op_secret.metadata.annotations
+            )
+            assert (
+                "vriesdemichael.github.io/keycloak-valid-until"
+                in op_secret.metadata.annotations
             )
 
             # 6. Verify token metadata stored in ConfigMap


### PR DESCRIPTION
## Summary
Refactor the release workflow to implement a **build-once, promote-on-release** pattern. This ensures released Docker images are byte-for-byte identical to the images that passed all tests.

## Changes

### 1. Commit Scope Validation
- Add `scripts/validate-commit-message.py` to enforce valid scopes
- Update `.pre-commit-config.yaml` to use custom validator
- Support multi-component scopes with `+` (e.g., `chart-client+chart-realm`)
- Enforce alphabetical ordering and prevent duplicates
- Update `RELEASES.md` with scope documentation

### 2. Build-Once Workflow
**`.github/workflows/ci-cd.yml`:**
- Remove triggers for `tags`, `release`, `repository_dispatch`
- Replace `publish` job with `push-sha-image` job
- Only publish `sha-{commit}` tag on main (no `latest` tag)
- Condition: `github.ref == 'refs/heads/main' && github.event_name == 'push'`

**`.github/workflows/promote-operator.yml` (new):**
- Triggers on `release` events only
- Filters operator releases: `startsWith(tag, 'v') && !contains(tag, 'chart-')`
- Pulls existing `sha-{commit}` image (no rebuild)
- Re-tags with: `v0.2.16`, `v0.2`, `v0`, `latest`
- Uploads SBOM to release assets
- Runs security scans on promoted image

**`.github/workflows/release-please.yml`:**
- Remove redundant `repository_dispatch` step
- Update summary to mention promote-operator workflow

### 3. Configuration Updates
**`.github/release-please-config.json`:**
- Change operator component name: `"operator"` → `"Operator Image"`
- Release PR titles now: "chore: release Operator Image 0.2.16"

**`RELEASES.md`:**
- Document new build-once-promote workflow
- Update all examples with new flow
- Add troubleshooting for SHA-based workflow
- Explain when `latest` tag updates (releases only)

## Breaking Change
⚠️ **BREAKING CHANGE:** The `latest` tag no longer updates on every push to main. It only updates when an operator release is created.

**Before:**
- Push to main → `latest` tag updated
- Unpredictable behavior (latest != stable)

**After:**
- Push to main → Only `sha-{commit}` tag created
- Release created → `latest` tag points to released version
- Predictable: `latest` always points to last stable release

## Benefits
1. ✅ **Immutable artifacts**: Released images are identical to tested images
2. ✅ **No rebuild inconsistencies**: Same image passes tests and gets released
3. ✅ **Predictable `latest` tag**: Always points to last stable release
4. ✅ **Audit trail**: SHA tags prove which commit was tested/released
5. ✅ **Faster releases**: No rebuild time, just re-tag existing image

## New Release Flow
```
PR merged to main
  ├─ Build operator image
  ├─ Run all tests  
  └─ Push ghcr.io/vriesdemichael/keycloak-operator:sha-abc123
  
Release-please PR merged
  ├─ Creates git tag v0.2.16
  └─ Creates GitHub Release
  
Promote-operator workflow (automatic)
  ├─ Pulls sha-abc123 (tested image)
  └─ Tags: v0.2.16, v0.2, v0, latest
```

## Test Plan
- [x] Verify commit scope validation works
- [ ] Test CI/CD workflow on main push (should only create sha-{commit} tag)
- [ ] Test promote-operator workflow on release (should re-tag existing image)
- [ ] Verify latest tag only updates on release
- [ ] Confirm chart releases don't trigger operator promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)