### PR TITLE
docs: fix ADR 45/49 and add decision records to documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,8 @@ on:
       - 'mkdocs.yml'
       - 'charts/**'
       - 'scripts/generate-crd-schemas.py'
+      - 'scripts/adr_to_markdown.py'
+      - 'scripts/build-adr-docs.sh'
       - '.github/workflows/pages.yml'
   release:
     types: [published]
@@ -132,6 +134,12 @@ jobs:
           echo "version=$DOC_VERSION" >> $GITHUB_OUTPUT
           echo "is_latest=$IS_LATEST" >> $GITHUB_OUTPUT
           echo "skip_docs=$SKIP_DOCS" >> $GITHUB_OUTPUT
+
+      - name: Generate decision record markdown
+        if: steps.doc-version.outputs.skip_docs != 'true'
+        run: |
+          echo "Generating decision record markdown from YAML..."
+          ./scripts/build-adr-docs.sh
 
       - name: Build versioned documentation with mike
         if: steps.doc-version.outputs.skip_docs != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ __marimo__/
 # Generated JSON schemas (published via GitHub Pages)
 _schemas/
 _site/
+
+# Generated markdown from decision records
+docs/decisions/generated-markdown/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,14 +50,14 @@ repos:
         files: ^charts/keycloak-operator/
         pass_filenames: false
 
-  # Documentation build check
+  # Documentation build check (generates decision records + builds docs)
   - repo: local
     hooks:
       - id: mkdocs-build
         name: mkdocs build
-        entry: uv run --group docs mkdocs build
+        entry: bash -c './scripts/build-adr-docs.sh && uv run --group docs mkdocs build'
         language: system
-        files: ^(docs/|mkdocs\.yml)
+        files: ^(docs/|mkdocs\.yml|scripts/adr_to_markdown\.py|scripts/build-adr-docs\.sh)
         pass_filenames: false
 
   # Decision Records validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -681,19 +681,29 @@ Before finishing your task, run through this mental checklist:
 Documentation is built with MkDocs. To build documentation locally:
 
 ```bash
-# Install documentation dependencies
-uv sync --group docs
+# Build documentation (generates decision records + builds site)
+make docs-build
 
-# Build documentation (generates static site in site/)
-uv run --group docs mkdocs build
+# Generate only decision record markdown (without building full site)
+make docs-generate-decisions
+
+# Clean generated documentation
+make docs-clean
 
 # Serve documentation locally (DO NOT USE AS LLM - creates endless process, HUMANS ONLY)
 uv run --group docs mkdocs serve
 # View at: http://127.0.0.1:8000
 ```
 
+**Decision Records in Documentation:**
+- Decision record YAML files in `docs/decisions/*.yaml` are automatically converted to Markdown
+- Generated markdown is placed in `docs/decisions/generated-markdown/` (gitignored)
+- The `make docs-build` target automatically generates decision record markdown before building
+- Decision records appear in the "Decision Records" section of the documentation site
+
 **When to update documentation:**
 - After adding/editing any `.md` files in `docs/`
+- After adding/editing decision record YAML files in `docs/decisions/`
 - To verify links work correctly
 - To check formatting and appearance
 - Before committing documentation changes

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,23 @@ validate-decisions: ## Validate Decision Records (Architecture/Development)
 	fi
 
 # ============================================================================
+# Documentation
+# ============================================================================
+
+.PHONY: docs-generate-decisions
+docs-generate-decisions: ## Generate markdown from decision record YAML files
+	@./scripts/build-adr-docs.sh
+
+.PHONY: docs-build
+docs-build: docs-generate-decisions ## Build documentation site
+	uv run --group docs mkdocs build
+
+.PHONY: docs-clean
+docs-clean: ## Clean generated documentation
+	rm -rf site/
+	rm -rf docs/decisions/generated-markdown/
+
+# ============================================================================
 # Unit Testing
 # ============================================================================
 

--- a/docs/decisions/045-single-operator-replica-with-horizontal-scaling-via-multiple-operators.yaml
+++ b/docs/decisions/045-single-operator-replica-with-horizontal-scaling-via-multiple-operators.yaml
@@ -1,24 +1,24 @@
 number: 45
-title: Single operator replica with horizontal scaling via multiple operators
+title: Active-standby HA using Kopf peering
 category: architecture
-decision: Run single replica of operator (no replication). If scaling needed, deploy
-  multiple operator instances each managing a subset of realms. Operator is not the
-  bottleneck.
-agent_instructions: 'Configure operator deployment with replicas: 1. Do not implement
-  leader election or active-passive HA. If users need more capacity, document deploying
-  multiple operator instances in different namespaces, each configured to watch different
-  realm subsets. Operator reconciles efficiently enough that single instance handles
-  typical loads.'
-rationale: Operator is not the bottleneck - Keycloak API is. Multiple operator replicas
-  would compete for same work, requiring leader election complexity. Single replica
-  is simpler, no split-brain risks. For large scale, deploy multiple operators each
-  responsible for subset of realms (sharding by realm). This scales better than vertical
-  scaling one operator. Most deployments will never need more than single operator.
+decision: Support high availability via active-standby replication (replicas > 1)
+  using Kopf's built-in peering mechanism. One replica is active (leader), others
+  are standby. Standby replicas take over if active fails. This is for availability,
+  not workload capacity scaling.
+agent_instructions: Operator supports active-standby HA via Kopf peering. Increasing
+  replicas improves availability but does NOT increase reconciliation capacity.
+rationale: Kopf provides built-in active-standby HA via peering - minimal implementation
+  effort. One active replica processes all events, standbys are ready to take over.
+  Prevents downtime during upgrades or failures. Operator is stateless so failover
+  is fast and safe. HA is justified for production environments where brief reconciliation
+  pauses are unacceptable. Standby replicas are not wasted - they provide fault tolerance.
+  Important distinction - this HA mechanism does NOT improve throughput or capacity.
+  Keycloak API is almost certainly the bottleneck, not the operator.
 provenance: human
 rejected_alternatives:
-- alternative: Active-passive HA with leader election
-  reason: Adds complexity (leader election, coordination). Passive replicas waste
-    resources. Operator not critical enough to justify.
+- alternative: No HA (single replica only)
+  reason: Acceptable for dev/test but production environments benefit from availability
+    during upgrades and failures.
 - alternative: Active-active with work distribution
-  reason: Very complex. Risk of conflicts. Operator reconciliation fast enough that
-    single replica sufficient.
+  reason: Very complex to implement. Risk of conflicts and split-brain. Kopf's active-standby
+    is simpler and sufficient for availability needs.

--- a/docs/decisions/049-no-ha-or-leader-election.yaml
+++ b/docs/decisions/049-no-ha-or-leader-election.yaml
@@ -1,26 +1,30 @@
 number: 49
-title: No HA or leader election
+title: Horizontal scaling via multiple operator deployments (realm sharding)
 category: architecture
-decision: No high availability or leader election. Single operator replica only. Operator
-  downtime acceptable during upgrades or failures. Reconciliation resumes when operator
-  restarts.
-agent_instructions: Do not implement leader election (Kopf supports it but we don't
-  use it). Configure deployment with single replica. Accept that operator downtime
-  means reconciliation pauses. Document that resource state is preserved and reconciliation
-  resumes on restart. For critical environments, minimize downtime with fast restarts,
-  not HA.
-rationale: Operator is not on critical path for running applications. Applications
-  use existing Keycloak state; operator only needed for configuration changes. Reconciliation
-  pausing during operator downtime is acceptable. HA adds complexity (leader election,
-  coordination) for minimal benefit. Kubernetes restarts failed operators quickly
-  (seconds). Most outages are planned (upgrades) and brief. Better to focus on fast
-  recovery than preventing all downtime. Stateless operator means no data loss on
-  restart.
+decision: Horizontal scaling of operator capacity is achieved by deploying multiple
+  operator instances, each managing a different subset of realms. This mimics classic
+  sharding but at the operator deployment level. HA replicas (ADR 45) are for availability
+  only, not capacity scaling.
+agent_instructions: Horizontal scaling uses multiple operator deployments, each managing
+  different realm subsets. Do not use HA replicas for capacity scaling.
+rationale: When operator reaches reconciliation capacity limits, deploy additional
+  operators rather than adding more replicas to a single deployment. Each operator
+  manages a different set of realms - effectively sharding by realm. This is simpler
+  than implementing proper work distribution/sharding within a single operator deployment,
+  and achieves the same result. Users configure CRs to reference specific operators.
+  Known limitation - all operators still monitor all CRs cluster-wide, but only reconcile
+  CRs that reference them. If monitoring overhead becomes an issue (unlikely for
+  99% of users - would require enormous clusters), there is no solution within this
+  architecture. Keycloak API is almost certainly the bottleneck before operator capacity
+  becomes an issue.
 provenance: human
 rejected_alternatives:
-- alternative: Active-passive HA with leader election
-  reason: Complexity not justified. Passive replica wastes resources. Operator downtime
-    impact minimal.
-- alternative: Active-active multi-leader
-  reason: Extremely complex. Risk of split-brain and resource conflicts. Not needed
-    for operator workload.
+- alternative: Use HA replicas for capacity scaling
+  reason: Active-standby HA (ADR 45) does not increase capacity - only one replica
+    is active. Would require complex active-active work distribution.
+- alternative: Implement proper sharding within single operator
+  reason: Much more complex to implement. Would still shard by realm, resulting in
+    essentially the same architecture but requiring more configuration in CRs.
+- alternative: Namespace-scoped operators to reduce monitoring overhead
+  reason: Loses ability to watch cross-namespace resources. Monitoring overhead is
+    negligible compared to reconciliation work.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
   - Development:
       - Getting Started: development.md
       - Testing: development/testing.md
+  - Decision Records: decisions/generated-markdown/
   - FAQ: faq.md
   - API Reference:
       - Overview: api/keycloak_operator.md

--- a/scripts/adr_to_markdown.py
+++ b/scripts/adr_to_markdown.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Convert ADR YAML files to Markdown for MkDocs."""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def yaml_to_markdown(yaml_path: Path) -> str:
+    """Convert a single ADR YAML file to Markdown."""
+    with open(yaml_path) as f:
+        adr = yaml.safe_load(f)
+
+    number = adr["number"]
+    title = adr["title"]
+    category = adr["category"]
+    decision = adr["decision"]
+    rationale = adr["rationale"]
+    agent_instructions = adr.get("agent_instructions", "")
+    provenance = adr.get("provenance", "unknown")
+    rejected_alternatives = adr.get("rejected_alternatives", [])
+
+    # Build markdown
+    md = f"""# ADR-{number:03d}: {title}
+
+**Category:** {category}
+**Provenance:** {provenance}
+
+## Decision
+
+{decision}
+
+## Rationale
+
+{rationale}
+"""
+
+    if agent_instructions:
+        md += f"""
+## Agent Instructions
+
+{agent_instructions}
+"""
+
+    if rejected_alternatives:
+        md += "\n## Rejected Alternatives\n\n"
+        for alt in rejected_alternatives:
+            alternative = alt.get("alternative", "")
+            reason = alt.get("reason", "")
+            md += f"### {alternative}\n\n{reason}\n\n"
+
+    return md
+
+
+def main():
+    """Convert ADR YAML file to Markdown."""
+    if len(sys.argv) != 2:
+        print("Usage: adr_to_markdown.py <yaml_file>", file=sys.stderr)
+        sys.exit(1)
+
+    yaml_path = Path(sys.argv[1])
+    if not yaml_path.exists():
+        print(f"Error: File not found: {yaml_path}", file=sys.stderr)
+        sys.exit(1)
+
+    markdown = yaml_to_markdown(yaml_path)
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build-adr-docs.sh
+++ b/scripts/build-adr-docs.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to generate Markdown documentation from decision record YAML files
+# This should be run before building documentation (mkdocs build)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DECISIONS_DIR="${PROJECT_ROOT}/docs/decisions"
+OUTPUT_DIR="${DECISIONS_DIR}/generated-markdown"
+
+echo "Generating decision record documentation..."
+
+# Create output directory
+mkdir -p "${OUTPUT_DIR}"
+
+# Convert each YAML file to Markdown
+for yaml_file in "${DECISIONS_DIR}"/*.yaml; do
+    if [[ -f "$yaml_file" ]]; then
+        basename=$(basename "$yaml_file" .yaml)
+        output_file="${OUTPUT_DIR}/${basename}.md"
+        echo "  Converting: $basename"
+        uv run python "${SCRIPT_DIR}/adr_to_markdown.py" "$yaml_file" > "$output_file"
+    fi
+done
+
+echo "Decision record documentation generated in ${OUTPUT_DIR}"
+echo "Total records: $(find "${OUTPUT_DIR}" -name "*.md" | wc -l)"


### PR DESCRIPTION
## Summary

- Fixes incorrect ADR descriptions for HA and horizontal scaling
- Implements decision record display in MkDocs documentation site

## Changes

### ADR Corrections (fixes #90)
- **ADR 45**: Now correctly describes active-standby HA via Kopf peering (availability, not capacity)
- **ADR 49**: Now correctly describes horizontal scaling via multiple operator deployments with realm sharding

### Documentation Feature (fixes #96)
- Created `scripts/adr_to_markdown.py` to convert YAML to markdown
- Created `scripts/build-adr-docs.sh` to generate all decision records
- Updated GitHub Actions workflow to generate records before build
- Added Makefile targets: `docs-build`, `docs-generate-decisions`, `docs-clean`
- Updated pre-commit hook to generate records during docs build
- Decision records now appear in "Decision Records" section of docs site

Generated markdown is placed in `docs/decisions/generated-markdown/` (gitignored) and automatically created from YAML source on each build.

## Test Plan

- [x] Pre-commit hooks pass (including mkdocs build)
- [x] Documentation builds locally with `make docs-build`
- [x] All 61 decision records generate correctly
- [x] Decision records appear in navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)