### PR TITLE
chore(operator): remove explicit aiohttp dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "pydantic>=2.0.0",
     "kubernetes>=28.0.0",
     "httpx>=0.27.0",
-    "aiohttp>=3.9.0",
     "prometheus-client>=0.20.0",
 ]
 

--- a/src/keycloak_operator/observability/metrics.py
+++ b/src/keycloak_operator/observability/metrics.py
@@ -10,6 +10,10 @@ import time
 from contextlib import asynccontextmanager
 from typing import Any
 
+# Note: aiohttp is not listed in pyproject.toml dependencies.
+# It's provided transitively by Kopf (required for webhooks and health probes).
+# We use it here to avoid adding duplicate dependencies while keeping HTTP server
+# implementation consistent with Kopf's own usage.
 from aiohttp.web import (
     Application,
     AppRunner,

--- a/uv.lock
+++ b/uv.lock
@@ -762,7 +762,6 @@ name = "keycloak-operator"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aiohttp" },
     { name = "httpx" },
     { name = "kopf" },
     { name = "kubernetes" },
@@ -819,7 +818,6 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "kopf", specifier = ">=1.37.0" },
     { name = "kubernetes", specifier = ">=28.0.0" },


### PR DESCRIPTION
## Summary
Removes `aiohttp` from `pyproject.toml` explicit dependencies as it's already provided transitively by Kopf (required for webhooks and health probes).

## Changes
- Removed `aiohttp>=3.9.0` from `dependencies` in `pyproject.toml`
- Added documentation comment in `metrics.py` explaining the transitive dependency to prevent future confusion during code reviews

## Testing
- ✅ Unit tests pass (all 282 tests)
- ✅ Code quality checks pass
- ✅ `aiohttp` still available transitively via Kopf
- ✅ `MetricsServer` imports and functions correctly

Resolves #51