### PR TITLE
docs: add helm values JSON schema requirement to ADR-030

### DIFF
--- a/docs/decisions/030-helm-charts-published-to-github-pages-oci-registry.yaml
+++ b/docs/decisions/030-helm-charts-published-to-github-pages-oci-registry.yaml
@@ -2,17 +2,23 @@ number: 30
 title: Helm charts published to GitHub Pages OCI registry
 category: development
 decision: Publish all three Helm charts (operator, realm, client) to GitHub Pages
-  which serves as an OCI registry. Charts are available at https://vriesdemichael.github.io/keycloak-operator/charts/
+  which serves as an OCI registry. Charts are available at https://vriesdemichael.github.io/keycloak-operator/charts/.
+  JSON schemas for Helm chart values are published alongside charts for IDE validation
+  and auto-completion.
 agent_instructions: Package Helm charts and publish to GitHub Pages charts directory.
   Maintain index.yaml with all chart versions. Charts are served via GitHub Pages
   and can be added to Helm with 'helm repo add'. Keep charts directory in gh-pages
   branch synchronized with releases. Never delete old chart versions - users may be
-  pinned to specific versions.
+  pinned to specific versions. When values.yaml changes in any chart, regenerate the
+  corresponding JSON schema for that chart's values to keep schemas in sync with supported
+  configuration options.
 rationale: GitHub Pages provides free, reliable hosting for Helm charts. OCI registry
   format allows versioned chart distribution. Users can pin to specific chart versions
   for stability. Helm repo index allows 'helm search repo' to discover versions. Integrated
   with release process - charts published automatically on release. No external registry
-  costs or management. Charts accessible globally via CDN with SSL.
+  costs or management. Charts accessible globally via CDN with SSL. Publishing JSON
+  schemas alongside charts enables IDE validation and auto-completion for values.yaml
+  files, improving developer experience and catching configuration errors early.
 provenance: human
 rejected_alternatives:
 - alternative: Use external chart registry (ChartMuseum, Harbor)


### PR DESCRIPTION
## Summary

Updates ADR-030 to include JSON schema publication for Helm chart values alongside chart distribution.

## Changes

- Added requirement to publish JSON schemas for Helm chart values to GitHub Pages
- Updated agent instructions to regenerate JSON schemas when values.yaml changes
- Extended rationale to explain IDE validation benefits

## Motivation

This formalizes the practice of providing JSON schemas for Helm chart values, enabling IDE validation and auto-completion similar to what we provide for CRDs in ADR-027.

## Notes

- Enables auto-rebase when tests pass
- No code changes, documentation only