### PR TITLE
docs: add ADR-064 rejecting force-delete feature

### DIFF
--- a/docs/decisions/064-no-force-delete-annotation.yaml
+++ b/docs/decisions/064-no-force-delete-annotation.yaml
@@ -1,0 +1,28 @@
+number: 64
+title: No force-delete annotation for finalizers
+category: development
+decision: No force-delete annotation for stuck finalizers. Users manually remove finalizers
+  with kubectl patch when Keycloak is permanently unavailable. Standard Kubernetes
+  pattern documented in troubleshooting guide.
+agent_instructions: Do not implement force-delete annotations or timeout-based finalizer
+  removal. When users report stuck resources, direct them to troubleshooting documentation
+  for manual finalizer removal. Finalizers exist to prevent orphaned resources in
+  Keycloak - removing them is user's explicit responsibility.
+rationale: Industry standard approach (cert-manager, CloudNativePG, most operators
+  rely on manual kubectl patch). Zero maintenance burden. Finalizers protect against
+  data leaks - automatic removal contradicts their purpose. Manual removal forces
+  user acknowledgment of consequences (orphaned realms/clients in Keycloak). Standard
+  kubectl patch command is well-documented and universally available. Feature can
+  be added later if proven necessary through usage patterns.
+provenance: human
+rejected_alternatives:
+- alternative: Immediate force-delete annotation
+  reason: Too dangerous - no safety net, encourages careless usage, leaves orphaned
+    resources in Keycloak without attempting cleanup.
+- alternative: Timeout-based automatic cleanup (Zalando PostgreSQL pattern)
+  reason: Added complexity for rare edge case. Users can manually patch immediately
+    if needed rather than waiting for timeout. Maintenance burden not justified by
+    infrequent use.
+- alternative: Two-step confirmation annotation
+  reason: Overly complex UX. Manual kubectl patch is simpler and achieves same result
+    with clear user responsibility.


### PR DESCRIPTION
## Summary

Adds ADR-064 documenting the decision to NOT implement a force-delete annotation for stuck finalizers.

Closes #33

## Decision

Follow industry standard pattern: document manual finalizer removal with `kubectl patch` instead of implementing automatic force-delete features.

## Rationale

- **Industry standard**: cert-manager, CloudNativePG, and most operators use manual removal
- **Zero maintenance**: No code to maintain, test, or support
- **Safety by design**: Finalizers prevent data leaks - manual removal ensures user acknowledges consequences
- **Simplicity**: Standard `kubectl patch` command is well-documented and universally available
- **Future flexibility**: Can add automated feature later if usage proves it necessary

## Rejected Alternatives

1. **Immediate force-delete annotation** - Too dangerous, no safety net
2. **Timeout-based cleanup** - Added complexity for rare edge case  
3. **Two-step confirmation** - Overly complex UX

## Next Steps

- Close issue #33 as "won't implement"
- Document manual finalizer removal in troubleshooting guide (future PR if needed)
- Users can use standard kubectl commands when Keycloak is unavailable:
  ```bash
  kubectl patch keycloakrealm my-realm -n my-ns \
    --type json \
    -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
  ```