### PR TITLE
fix: simplify coverage - always on, fail hard, let codecov combine

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build operator image (test)
+      - name: Build operator image (coverage always on)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -225,29 +225,11 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Build operator image (test-coverage)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: images/operator/Dockerfile
-          platforms: linux/amd64
-          tags: keycloak-operator:test-coverage
-          outputs: type=docker,dest=/tmp/operator-test-coverage.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Upload test image artifact
+      - name: Upload image artifact
         uses: actions/upload-artifact@v5
         with:
           name: operator-image
           path: /tmp/operator-test.tar
-          retention-days: 1
-
-      - name: Upload coverage image artifact
-        uses: actions/upload-artifact@v5
-        with:
-          name: operator-coverage-image
-          path: /tmp/operator-test-coverage.tar
           retention-days: 1
 
   # =====================================================
@@ -502,16 +484,8 @@ jobs:
           name: operator-image
           path: /tmp
 
-      - name: Download operator coverage image
-        uses: actions/download-artifact@v6
-        with:
-          name: operator-coverage-image
-          path: /tmp
-
-      - name: Load operator images
-        run: |
-          docker load --input /tmp/operator-test.tar
-          docker load --input /tmp/operator-test-coverage.tar
+      - name: Load operator image
+        run: docker load --input /tmp/operator-test.tar
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -532,11 +506,8 @@ jobs:
           kubectl get nodes
           kubectl get pods -A
 
-      - name: Load operator images into Kind
-        run: |
-          # Load both test and coverage images into kind cluster
-          kind load docker-image keycloak-operator:test --name test-${{ github.run_id }}
-          kind load docker-image keycloak-operator:test-coverage --name test-${{ github.run_id }}
+      - name: Load operator image into Kind
+        run: kind load docker-image keycloak-operator:test --name test-${{ github.run_id }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -586,57 +557,16 @@ jobs:
           INTEGRATION_COVERAGE: "true"
         run: uv run --group test pytest tests/integration/ -v -n auto --dist=loadscope
 
-      - name: Generate integration coverage report
-        if: always()
-        run: |
-          echo "Generating coverage XML report from integration tests..."
-
-          # Check if integration coverage was collected by pytest fixture
-          if [ -d .tmp/coverage ] && [ -n "$(ls -A .tmp/coverage/.coverage* 2>/dev/null)" ]; then
-            echo "Found integration coverage files:"
-            ls -la .tmp/coverage/
-
-            # Combine integration coverage files and generate XML report
-            uv run coverage combine .tmp/coverage/.coverage*
-            uv run coverage xml -o coverage.xml
-            echo "✓ Generated coverage.xml from integration tests"
-          else
-            echo "ERROR: No integration coverage files found in .tmp/coverage/"
-            echo "Coverage collection may have failed during pytest teardown"
-            ls -la .tmp/ || echo "No .tmp directory found"
-            exit 1
-          fi
-
-      - name: Upload integration coverage to Codecov (try CLI first)
-        id: codecov_integration_cli
+      - name: Upload integration coverage to Codecov
         uses: codecov/codecov-action@v5
-        continue-on-error: true
         if: always() && github.actor != 'dependabot[bot]'
         with:
-          files: ./coverage.xml
+          files: .tmp/coverage/.coverage.*
           flags: integration
           name: integration-tests
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true
-          fail_ci_if_error: false
-
-      - name: Upload integration coverage to Codecov (fallback to legacy)
-        if: always() && github.actor != 'dependabot[bot]' && steps.codecov_integration_cli.outcome == 'failure'
-        uses: codecov/codecov-action@v5
-        continue-on-error: true
-        with:
-          files: ./coverage.xml
-          flags: integration
-          name: integration-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
-          fail_ci_if_error: false
-          use_legacy_upload_endpoint: true
-
-      - name: Check integration coverage upload
-        if: always() && github.actor != 'dependabot[bot]' && steps.codecov_integration_cli.outcome == 'failure'
-        run: |
-          echo "::warning::Codecov CLI upload failed for integration tests, used legacy endpoint as fallback (allowing failures due to outage)"
+          fail_ci_if_error: true
 
       - name: Collect logs and diagnostics
         if: always()
@@ -1205,9 +1135,6 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
-      - name: Install dependencies
-        run: uv sync --frozen --group docs
-
       - name: Build ADR documentation
         run: bash scripts/build-adr-docs.sh
 
@@ -1220,8 +1147,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy dev docs with mike
-        run: |
-          uv run --group docs mike deploy --push dev
+        run: uv run --group docs mike deploy --push dev
 
   publish-release-docs:
     name: Publish Release Documentation


### PR DESCRIPTION
## Problem

PR #144 overcomplicated the coverage solution by trying to:
- Build TWO images (test + test-coverage)
- Combine coverage files manually
- Generate XML before upload
- Allow soft failures

## Correct Approach

**Coverage is ALWAYS ON in CI** - no need for separate images or complicated steps.

## Changes

### Coverage (Simplified)
- ✅ ONE image build (coverage always instrumented)
- ✅ Upload raw `.coverage.*` files to Codecov
- ✅ **Let Codecov combine** the coverage files itself
- ✅ `fail_ci_if_error: true` - **FAIL HARD** if upload fails
- ❌ Removed separate test-coverage image
- ❌ Removed manual coverage combine step
- ❌ Removed XML generation step

### Dev Docs (Simplified)
- ✅ Use `uv run --group docs <command>` (no sync needed)
- ❌ Removed `uv sync --frozen --group docs`

## Why This Works

1. **Coverage is always on** - The operator image is built with coverage instrumentation in CI
2. **Codecov combines** - Upload multiple `.coverage.*` files, Codecov handles merging
3. **Fail hard** - No more silent failures, forces fixing coverage issues immediately
4. **uv run handles deps** - No need to pre-sync when using `--group`

## Supersedes

This PR **replaces** #144 with the correct, simpler approach.

Closes task list item #2 from `TODO/cicd-documentation-issues.md`