### PR TITLE
fix: use Dockerfile.test for coverage-instrumented image

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -214,11 +214,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build operator image (coverage always on)
+      - name: Build operator image (test with coverage)
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: images/operator/Dockerfile
+          file: images/operator/Dockerfile.test
           platforms: linux/amd64
           tags: keycloak-operator:test
           outputs: type=docker,dest=/tmp/operator-test.tar


### PR DESCRIPTION
## Problem

PRs #144 and #145 broke integration tests by using the wrong Dockerfile:
- **Built with**: `images/operator/Dockerfile` (production, no coverage)
- **Should build**: `images/operator/Dockerfile.test` (coverage-instrumented)

Result: All integration tests ERROR because operator isn't instrumented for coverage collection.

## Root Cause

The project has TWO Dockerfiles:
- `Dockerfile` - Production image (no test deps, no coverage)
- `Dockerfile.test` - Test image (includes coverage, runs with `coverage run`)

CI was using production Dockerfile, so operator starts but doesn't collect coverage.

## Fix

Change `file:` parameter from `images/operator/Dockerfile` to `images/operator/Dockerfile.test`

## Dockerfile.test Features

- Installs test dependencies (`--group test` includes coverage)
- Copies coverage config files
- Sets up coverage environment vars
- CMD: `coverage run --parallel-mode -m keycloak_operator.operator`

## Verification

This should fix the failing integration tests in latest main runs.