### PR TITLE
fix: use test-coverage tag for operator image

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -220,7 +220,7 @@ jobs:
           context: .
           file: images/operator/Dockerfile.test
           platforms: linux/amd64
-          tags: keycloak-operator:test
+          tags: keycloak-operator:test-coverage
           outputs: type=docker,dest=/tmp/operator-test.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -507,7 +507,7 @@ jobs:
           kubectl get pods -A
 
       - name: Load operator image into Kind
-        run: kind load docker-image keycloak-operator:test --name test-${{ github.run_id }}
+        run: kind load docker-image keycloak-operator:test-coverage --name test-${{ github.run_id }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Problem

Integration tests failing with:
```
Error from server (BadRequest): container "operator" in pod "keycloak-operator-55ddc59c45-rs4dq" 
is waiting to start: ErrImageNeverPull
```

## Root Cause

**Tag mismatch**:
- CI builds: `keycloak-operator:test`
- Test fixture expects: `keycloak-operator:test-coverage` (when INTEGRATION_COVERAGE=true)

From `tests/integration/conftest.py:1094`:
```python
"tag": "test-coverage" if coverage_enabled else "test",
```

Since `INTEGRATION_COVERAGE=true` is always set in CI, tests look for  tag which doesn't exist.

## Fix

Build and load image with the correct tag:
- Build as: `keycloak-operator:test-coverage`
- Load into Kind: `keycloak-operator:test-coverage`

Now the tag matches what the Helm values override specifies.

## Verification

This should fix the Helm install timeout and allow integration tests to run.