### PR TITLE
fix: update security scans to use test-coverage tag

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -399,7 +399,7 @@ jobs:
       - name: Trivy scan (SARIF)
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'keycloak-operator:test'
+          image-ref: 'keycloak-operator:test-coverage'
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
@@ -414,7 +414,7 @@ jobs:
       - name: Trivy scan (table, fail on critical)
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'keycloak-operator:test'
+          image-ref: 'keycloak-operator:test-coverage'
           format: 'table'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'
@@ -423,7 +423,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: keycloak-operator:test
+          image: keycloak-operator:test-coverage
           format: spdx-json
           output-file: sbom.spdx.json
 


### PR DESCRIPTION
## Problem

Security scan failing with:
```
FATAL: unable to find the specified image "keycloak-operator:test"
```

## Root Cause

Same issue as PR #147 - the image is now tagged as `test-coverage` but security scans were still looking for `test`.

## Changes

Update all security scan references:
- Trivy SARIF scan: `keycloak-operator:test-coverage`
- Trivy table scan: `keycloak-operator:test-coverage`
- SBOM generation: `keycloak-operator:test-coverage`

## Related

Follows PR #147 which changed the image tag from `:test` to `:test-coverage` to match what integration tests expect.