### PR TITLE
fix: combine coverage and convert to XML for Codecov

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -557,11 +557,32 @@ jobs:
           INTEGRATION_COVERAGE: "true"
         run: uv run --group test pytest tests/integration/ -v -n auto --dist=loadscope
 
+      - name: Combine and convert coverage to XML
+        if: always()
+        run: |
+          echo "Combining coverage files and generating XML..."
+          if [ -d .tmp/coverage ] && [ -n "$(ls -A .tmp/coverage/.coverage* 2>/dev/null)" ]; then
+            echo "Found coverage files:"
+            ls -la .tmp/coverage/
+
+            # Combine all .coverage.* files
+            uv run coverage combine .tmp/coverage/.coverage*
+
+            # Generate XML report for Codecov
+            uv run coverage xml -o coverage.xml
+
+            echo "✓ Generated coverage.xml"
+            ls -lh coverage.xml
+          else
+            echo "ERROR: No coverage files found in .tmp/coverage/"
+            exit 1
+          fi
+
       - name: Upload integration coverage to Codecov
         uses: codecov/codecov-action@v5
         if: always() && github.actor != 'dependabot[bot]'
         with:
-          files: .tmp/coverage/.coverage.*
+          files: ./coverage.xml
           flags: integration
           name: integration-tests
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem

Codecov failing with:
```
Unusable report due to issues such as source code unavailability, 
path mismatch, empty report, or incorrect data format.
```

## Root Cause

I incorrectly removed the coverage combine/XML generation step in PR #145, thinking Codecov would handle raw `.coverage.*` files. **Codecov requires XML format (Cobertura).**

## Fix - Restored Working Config

Based on last working commit (15c702ed), restored the exact steps:

```yaml
- name: Combine and convert coverage to XML
  run: |
    # Combine all .coverage.* files from parallel workers
    uv run coverage combine .tmp/coverage/.coverage*
    
    # Generate XML in Cobertura format
    uv run coverage xml -o coverage.xml

- name: Upload integration coverage to Codecov
  with:
    files: ./coverage.xml  # XML, not .coverage files!
```

## Why This Works

1. **Parallel workers** create separate `.coverage.worker_id` files
2. **Combine** merges them into a single `.coverage` database
3. **XML generation** converts to Cobertura format Codecov understands
4. **Upload** sends the XML file

Codecov **cannot** parse raw Python coverage database files - it needs XML.

## Verification

This matches the exact approach that worked in commit 15c702ed.