### PR TITLE
ci: correct job dependencies in all-complete job

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -1270,7 +1270,9 @@ jobs:
           fi
 
           if [[ "${{ needs.publish-operator-image.result }}" == "failure" ]] || \
-             [[ "${{ needs.publish-helm-charts.result }}" == "failure" ]] || \
+             [[ "${{ needs.publish-chart-operator.result }}" == "failure" ]] || \
+             [[ "${{ needs.publish-chart-realm.result }}" == "failure" ]] || \
+             [[ "${{ needs.publish-chart-client.result }}" == "failure" ]] || \
              [[ "${{ needs.publish-release-docs.result }}" == "failure" ]] || \
              [[ "${{ needs.update-dev-docs.result }}" == "failure" ]]; then
             echo "❌ Publishing failed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

The `all-complete` job references a non-existent job `publish-helm-charts`:

```yaml
if [[ "${{ needs.publish-helm-charts.result }}" == "failure" ]]; then
```

But this job doesn't exist! The workflow has individual chart publishing jobs:
- `publish-chart-operator`
- `publish-chart-realm`
- `publish-chart-client`

## Root Cause

Leftover from workflow consolidation - the old workflow had a single `publish-helm-charts` job, but the unified workflow split it into three separate jobs.

## Fix

Replace the single `publish-helm-charts` check with checks for each individual chart job:

```yaml
if [[ "${{ needs.publish-operator-image.result }}" == "failure" ]] || \
   [[ "${{ needs.publish-chart-operator.result }}" == "failure" ]] || \
   [[ "${{ needs.publish-chart-realm.result }}" == "failure" ]] || \
   [[ "${{ needs.publish-chart-client.result }}" == "failure" ]] || \
   [[ "${{ needs.publish-release-docs.result }}" == "failure" ]] || \
   [[ "${{ needs.update-dev-docs.result }}" == "failure" ]]; then
```

This now matches the actual job names declared in the `needs` list.

## Impact

- ✅ Workflow completion check now works correctly
- ✅ Catches failures from all chart publishing jobs
- ✅ Matches the job dependencies in the `needs` array