### PR TITLE
fix(chart-operator): remove outdated authorization token instructions

### DIFF
--- a/charts/keycloak-operator/templates/NOTES.txt
+++ b/charts/keycloak-operator/templates/NOTES.txt
@@ -14,34 +14,14 @@
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-🔑 OPERATOR AUTHORIZATION TOKEN
-
-To create KeycloakRealm resources, you need the operator's authorization token.
-
-1️⃣  Wait for the operator to generate the token:
-
-    kubectl wait --for=condition=available deployment/{{ include "keycloak-operator.fullname" . }} \
-      -n {{ include "keycloak-operator.namespace" . }} --timeout=300s
-
-2️⃣  Retrieve the operator authorization token:
-
-    kubectl get secret keycloak-operator-auth-token \
-      -n {{ include "keycloak-operator.namespace" . }} \
-      -o jsonpath='{.data.token}' | base64 -d
-
-    Save this token - you'll need to reference it in your KeycloakRealm specs!
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
 📚 NEXT STEPS
 
 To create a realm:
 
-1. Install the keycloak-realm chart with the operator token:
+1. Install the keycloak-realm chart:
 
    helm install my-realm keycloak-realm \
-     --set operatorRef.namespace={{ include "keycloak-operator.namespace" . }} \
-     --set operatorRef.authorizationSecretRef.name=keycloak-operator-auth-token
+     --set operatorRef.namespace={{ include "keycloak-operator.namespace" . }}
 
 2. Monitor the realm status:
 


### PR DESCRIPTION
Removes the outdated authorization token section from the operator chart NOTES.txt.

**Changes:**
- Removed entire section about operator authorization tokens
- Simplified helm install example for realm chart

**Reason:**
Authorization tokens are no longer required with the current RBAC model. The instructions were misleading and outdated.

**Scope:**
Uses `fix(chart-operator)` scope which will trigger a patch release of the chart-operator component.