### PR TITLE
ci: mark failed release PRs with 'autorelease: failed' label

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -445,8 +445,9 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**To fix this:**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "1. Find the release PR with 'autorelease: pending' label:" >> $GITHUB_STEP_SUMMARY
+            echo "1. Find the release PR with 'autorelease: failed' or 'autorelease: pending' label:" >> $GITHUB_STEP_SUMMARY
             echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "   gh pr list --state merged --label 'autorelease: failed' --json number,title,mergeCommit" >> $GITHUB_STEP_SUMMARY
             echo "   gh pr list --state merged --label 'autorelease: pending' --json number,title,mergeCommit" >> $GITHUB_STEP_SUMMARY
             echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -465,9 +466,11 @@ jobs:
             echo "   gh release create vX.Y.Z --title 'vX.Y.Z' --notes 'See CHANGELOG.md' --target <merge-commit-sha>" >> $GITHUB_STEP_SUMMARY
             echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "4. Update the PR label from 'pending' to 'tagged':" >> $GITHUB_STEP_SUMMARY
+            echo "4. Update the PR label to 'tagged':" >> $GITHUB_STEP_SUMMARY
             echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
-            echo "   gh api repos/OWNER/REPO/issues/PR_NUMBER/labels/autorelease%3A%20pending -X DELETE" >> $GITHUB_STEP_SUMMARY
+            echo "   # Remove failed or pending label and add tagged" >> $GITHUB_STEP_SUMMARY
+            echo "   gh api repos/OWNER/REPO/issues/PR_NUMBER/labels/autorelease%3A%20failed -X DELETE 2>/dev/null || true" >> $GITHUB_STEP_SUMMARY
+            echo "   gh api repos/OWNER/REPO/issues/PR_NUMBER/labels/autorelease%3A%20pending -X DELETE 2>/dev/null || true" >> $GITHUB_STEP_SUMMARY
             echo "   gh api repos/OWNER/REPO/issues/PR_NUMBER/labels -f 'labels[]=autorelease: tagged'" >> $GITHUB_STEP_SUMMARY
             echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -476,6 +479,30 @@ jobs:
           fi
 
           echo "✅ No untagged release PR issues detected"
+
+      # Mark any pending release PRs as failed if we detected untagged PRs
+      # This runs even on failure to help with debugging
+      - name: Mark pending releases as failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          echo "Checking for merged release PRs with 'autorelease: pending' label..."
+
+          # Find merged PRs with pending label and change to failed
+          PENDING_PRS=$(gh pr list --state merged --label 'autorelease: pending' --json number --jq '.[].number' 2>/dev/null || echo "")
+
+          if [[ -n "$PENDING_PRS" ]]; then
+            echo "Found pending release PRs: $PENDING_PRS"
+            for pr in $PENDING_PRS; do
+              echo "Marking PR #$pr as failed..."
+              gh api repos/${{ github.repository }}/issues/$pr/labels/autorelease%3A%20pending -X DELETE 2>/dev/null || true
+              gh api repos/${{ github.repository }}/issues/$pr/labels -f 'labels[]=autorelease: failed' 2>/dev/null || true
+            done
+            echo "✅ Marked pending release PRs as failed"
+          else
+            echo "No pending release PRs found"
+          fi
 
       - name: Release summary
         if: steps.release.outputs.release_created == 'true'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
           sarif_file: results.sarif
 
       - name: Upload SARIF results as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: scorecard-results
           path: results.sarif


### PR DESCRIPTION
## Summary

When release-please fails to create tags/releases for a merged release PR, the `autorelease: pending` label now gets changed to `autorelease: failed`.

## Label States

| Label | Meaning |
|-------|---------|
| `autorelease: pending` | Waiting for next run to create tag (normal state after PR merge) |
| `autorelease: failed` | Release-please failed, needs manual intervention |
| `autorelease: tagged` | Successfully completed |

## Changes

1. **New step: "Mark pending releases as failed"**
   - Runs on job failure
   - Changes `autorelease: pending` → `autorelease: failed` on merged PRs
   - Makes it clear something went wrong

2. **Updated fix instructions**
   - Now checks for both `failed` and `pending` labels
   - Includes commands to remove either label before adding `tagged`

3. **Dependabot update (PR #186)**
   - Bump `actions/upload-artifact` from v5 to v6

## Why This Helps

Previously when release-please timed out:
- Label stayed as `pending`
- Looked like normal state waiting for next run
- But next run would just abort again

Now:
- Label changes to `failed`
- Immediately clear something went wrong
- Manual intervention needed