### PR TITLE
ci: fix shell escaping for release-please PR output

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -383,26 +383,53 @@ jobs:
       # Determine which attempt succeeded and set outputs
       - name: Set release outputs
         id: release
+        env:
+          # Pass outputs via environment variables to avoid shell escaping issues
+          RELEASE_1_CREATED: ${{ steps.release-1.outputs.release_created }}
+          RELEASES_1_CREATED: ${{ steps.release-1.outputs.releases_created }}
+          TAG_1_NAME: ${{ steps.release-1.outputs.tag_name }}
+          PR_1: ${{ steps.release-1.outputs.pr }}
+          RELEASE_2_CREATED: ${{ steps.release-2.outputs.release_created }}
+          RELEASES_2_CREATED: ${{ steps.release-2.outputs.releases_created }}
+          TAG_2_NAME: ${{ steps.release-2.outputs.tag_name }}
+          PR_2: ${{ steps.release-2.outputs.pr }}
+          RELEASE_3_CREATED: ${{ steps.release-3.outputs.release_created }}
+          RELEASES_3_CREATED: ${{ steps.release-3.outputs.releases_created }}
+          TAG_3_NAME: ${{ steps.release-3.outputs.tag_name }}
+          PR_3: ${{ steps.release-3.outputs.pr }}
         run: |
           # Check which attempt succeeded (in order)
+          # Use heredoc syntax for pr output to handle special characters
           if [[ "${{ steps.release-1.outcome }}" == "success" ]]; then
             echo "Release Please succeeded on attempt 1"
-            echo "release_created=${{ steps.release-1.outputs.release_created }}" >> $GITHUB_OUTPUT
-            echo "releases_created=${{ steps.release-1.outputs.releases_created }}" >> $GITHUB_OUTPUT
-            echo "tag_name=${{ steps.release-1.outputs.tag_name }}" >> $GITHUB_OUTPUT
-            echo "pr=${{ steps.release-1.outputs.pr }}" >> $GITHUB_OUTPUT
+            echo "release_created=$RELEASE_1_CREATED" >> $GITHUB_OUTPUT
+            echo "releases_created=$RELEASES_1_CREATED" >> $GITHUB_OUTPUT
+            echo "tag_name=$TAG_1_NAME" >> $GITHUB_OUTPUT
+            {
+              echo 'pr<<EOF'
+              echo "$PR_1"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
           elif [[ "${{ steps.release-2.outcome }}" == "success" ]]; then
             echo "Release Please succeeded on attempt 2"
-            echo "release_created=${{ steps.release-2.outputs.release_created }}" >> $GITHUB_OUTPUT
-            echo "releases_created=${{ steps.release-2.outputs.releases_created }}" >> $GITHUB_OUTPUT
-            echo "tag_name=${{ steps.release-2.outputs.tag_name }}" >> $GITHUB_OUTPUT
-            echo "pr=${{ steps.release-2.outputs.pr }}" >> $GITHUB_OUTPUT
+            echo "release_created=$RELEASE_2_CREATED" >> $GITHUB_OUTPUT
+            echo "releases_created=$RELEASES_2_CREATED" >> $GITHUB_OUTPUT
+            echo "tag_name=$TAG_2_NAME" >> $GITHUB_OUTPUT
+            {
+              echo 'pr<<EOF'
+              echo "$PR_2"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
           elif [[ "${{ steps.release-3.outcome }}" == "success" ]]; then
             echo "Release Please succeeded on attempt 3"
-            echo "release_created=${{ steps.release-3.outputs.release_created }}" >> $GITHUB_OUTPUT
-            echo "releases_created=${{ steps.release-3.outputs.releases_created }}" >> $GITHUB_OUTPUT
-            echo "tag_name=${{ steps.release-3.outputs.tag_name }}" >> $GITHUB_OUTPUT
-            echo "pr=${{ steps.release-3.outputs.pr }}" >> $GITHUB_OUTPUT
+            echo "release_created=$RELEASE_3_CREATED" >> $GITHUB_OUTPUT
+            echo "releases_created=$RELEASES_3_CREATED" >> $GITHUB_OUTPUT
+            echo "tag_name=$TAG_3_NAME" >> $GITHUB_OUTPUT
+            {
+              echo 'pr<<EOF'
+              echo "$PR_3"
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
           else
             echo "### ❌ Release Please Failed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes shell escaping error in the release-please output handling.

## Problem

```
/home/runner/work/_temp/e815fc90-162d-4e9b-9d26-ad1da5895557.sh: line 7: syntax error near unexpected token `<'
```

The release-please PR output contains JSON with HTML tags like `<details>` in the body. When using inline expansion like:
```bash
echo "pr=${{ steps.release-1.outputs.pr }}" >> $GITHUB_OUTPUT
```

The shell interprets `<details>` as a redirection, causing a syntax error.

## Solution

1. Pass outputs via environment variables instead of inline `${{ }}` expansion
2. Use heredoc syntax for the `pr` output to handle special characters safely:
```bash
{
  echo 'pr<<EOF'
  echo "$PR_1"
  echo 'EOF'
} >> $GITHUB_OUTPUT
```

## Testing

This should fix the CI failure on main.