### PR TITLE
chore: reset release-please manifest to match actual tags

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  ".": "0.6.0",
-  "charts/keycloak-operator": "0.5.0",
+  ".": "0.4.2",
+  "charts/keycloak-operator": "0.3.0",
   "charts/keycloak-client": "0.3.0",
   "charts/keycloak-realm": "0.3.0"
 }


### PR DESCRIPTION
## Problem

The release-please manifest has drifted out of sync with actual released tags. This happened because multiple release PRs merged but failed to create the corresponding tags/releases.

**Current manifest claims:**
- Operator: `0.6.0`
- Chart operator: `0.5.0`

**Actual latest tags:**
- Operator: `v0.4.2`
- Chart operator: `chart-operator-v0.3.0`

This causes release-please to be in a confused state where it thinks versions exist that don't, preventing proper release operations.

## Solution

Reset the manifest to match the actual released tags:
```json
{
  ".": "0.4.2",
  "charts/keycloak-operator": "0.3.0",
  "charts/keycloak-client": "0.3.0",
  "charts/keycloak-realm": "0.3.0"
}
```

## What Happens After Merge

Once this merges:
1. Release-please will scan commits since v0.4.2 and chart-operator-v0.3.0
2. It will create a new release PR with the accumulated changes
3. The release process will work correctly going forward

## Related

This is a cleanup step to fix the CI/CD pipeline after the refactor in PR #198.