### PR TITLE
feat(chart-operator): add documentation link to values.yaml header

### DIFF
--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -1,6 +1,8 @@
 # Default values for keycloak-operator.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+#
+# For full documentation, see: https://vriesdemichael.github.io/keycloak-operator/
 
 # ============================================================================
 # Operator Configuration


### PR DESCRIPTION
## Summary

Add documentation link to the values.yaml header for easier reference when configuring the chart.

## Changes

- Added link to full documentation in the values.yaml header comment

## Purpose

This is a test of the new separate release PR workflow. When merged, release-please should:
1. Create a separate release PR for `chart-operator` only
2. The PR title should be parseable: `chore(main): release chart-operator 0.3.2`
3. When that PR is merged, tags and releases should be created automatically