### PR TITLE
chore: fix release-please exit code when not all components release

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -391,10 +391,10 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           if [[ "${RELEASES_CREATED:-false}" == "true" ]]; then
             echo "**Components Released:**" >> $GITHUB_STEP_SUMMARY
-            [[ "$OP_RELEASED" == "true" ]] && echo "- ✅ Operator: v${OP_VERSION}" >> $GITHUB_STEP_SUMMARY
-            [[ "$CHART_OP_RELEASED" == "true" ]] && echo "- ✅ Chart Operator: v${CHART_OP_VERSION}" >> $GITHUB_STEP_SUMMARY
-            [[ "$CHART_REALM_RELEASED" == "true" ]] && echo "- ✅ Chart Realm: v${CHART_REALM_VERSION}" >> $GITHUB_STEP_SUMMARY
-            [[ "$CHART_CLIENT_RELEASED" == "true" ]] && echo "- ✅ Chart Client: v${CHART_CLIENT_VERSION}" >> $GITHUB_STEP_SUMMARY
+            [[ "$OP_RELEASED" == "true" ]] && echo "- ✅ Operator: v${OP_VERSION}" >> $GITHUB_STEP_SUMMARY || true
+            [[ "$CHART_OP_RELEASED" == "true" ]] && echo "- ✅ Chart Operator: v${CHART_OP_VERSION}" >> $GITHUB_STEP_SUMMARY || true
+            [[ "$CHART_REALM_RELEASED" == "true" ]] && echo "- ✅ Chart Realm: v${CHART_REALM_VERSION}" >> $GITHUB_STEP_SUMMARY || true
+            [[ "$CHART_CLIENT_RELEASED" == "true" ]] && echo "- ✅ Chart Client: v${CHART_CLIENT_VERSION}" >> $GITHUB_STEP_SUMMARY || true
           elif [[ -n "$PRS" && "$PRS" != "[]" ]]; then
             echo "**Release PRs:** Created/Updated" >> $GITHUB_STEP_SUMMARY
           else


### PR DESCRIPTION
## Problem

The release-please job failed with exit code 1 when creating a release for `chart-operator` only.

**Root cause:** The script uses `[[ condition ]] && echo` pattern which returns exit code 1 when the condition is false. With `bash -e`, this causes the script to fail.

```bash
# This returns exit code 1 when OP_RELEASED is not "true"
[[ "$OP_RELEASED" == "true" ]] && echo "- ✅ Operator: v${OP_VERSION}" >> $GITHUB_STEP_SUMMARY
```

## Solution

Added `|| true` to prevent the exit code from propagating:

```bash
[[ "$OP_RELEASED" == "true" ]] && echo "- ✅ Operator: v${OP_VERSION}" >> $GITHUB_STEP_SUMMARY || true
```

## Impact

This fixes the release-please job failure that occurred when only one component (e.g., chart-operator) was released but not others.