### PR TITLE
chore: add auto-rebase for conflicted release PRs and rename operator component

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,11 +3,16 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "component": "operator",
+      "component": "operator-image",
       "package-name": "keycloak-operator",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "include-component-in-tag": false,
+      "include-component-in-tag": true,
+      "exclude-paths": [
+        "charts/keycloak-operator",
+        "charts/keycloak-realm",
+        "charts/keycloak-client"
+      ],
       "changelog-sections": [
         {"type": "feat", "section": "Features", "hidden": false},
         {"type": "fix", "section": "Bug Fixes", "hidden": false},

--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -550,7 +550,7 @@ jobs:
       name: ghcr-chart-operator
       url: https://github.com/${{ github.repository }}/pkgs/container/charts%2Fkeycloak-operator
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
       attestations: write
@@ -567,6 +567,29 @@ jobs:
           registry-owner: ${{ github.repository_owner }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-actor: ${{ github.actor }}
+
+      - name: Create primary version tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHART_VERSION: ${{ needs.release-please.outputs.chart_operator_version }}
+        run: |
+          # The chart-operator is the primary artifact, so we also tag it with just v{version}
+          # This allows users to reference the "main" version without the chart- prefix
+          PRIMARY_TAG="v${CHART_VERSION}"
+          COMPONENT_TAG="chart-operator-v${CHART_VERSION}"
+
+          echo "Creating primary tag $PRIMARY_TAG pointing to same commit as $COMPONENT_TAG"
+
+          # Get the commit SHA for the component tag
+          COMMIT_SHA=$(git rev-parse HEAD)
+
+          # Create the primary tag (lightweight tag pointing to same commit)
+          git tag "$PRIMARY_TAG" "$COMMIT_SHA" 2>/dev/null || echo "Tag $PRIMARY_TAG already exists"
+          git push origin "$PRIMARY_TAG" 2>/dev/null || echo "Tag $PRIMARY_TAG already pushed"
+
+          echo "### 🏷️ Primary Version Tag" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Created \`$PRIMARY_TAG\` pointing to chart-operator release" >> $GITHUB_STEP_SUMMARY
 
   publish-chart-realm:
     name: Publish Helm Chart (Realm)

--- a/.github/workflows/rebase-release-prs.yml
+++ b/.github/workflows/rebase-release-prs.yml
@@ -1,0 +1,70 @@
+name: Rebase Conflicted Release PRs
+
+# When a release PR merges, other pending release PRs may have manifest conflicts.
+# This workflow automatically triggers a rebase for any conflicted release PRs.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  rebase-conflicted:
+    name: Rebase Conflicted Release PRs
+    runs-on: ubuntu-latest
+    # Only run if this push might have created conflicts (e.g., release PR merge)
+    steps:
+      - name: Check for conflicted release PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Checking for conflicted release PRs..."
+
+          # GitHub's mergeable status can be null while being computed.
+          # Retry a few times with a short delay to allow computation to complete.
+          PENDING_PRS=""
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt: Fetching release PR status..."
+
+            RESPONSE=$(gh pr list \
+              --repo ${{ github.repository }} \
+              --label "autorelease: pending" \
+              --json number,title,mergeable)
+
+            # Find PRs with CONFLICTING status
+            PENDING_PRS=$(echo "$RESPONSE" | jq -r '.[] | select(.mergeable == "CONFLICTING") | .number')
+
+            # Check if any PRs still have null mergeable status
+            NULL_COUNT=$(echo "$RESPONSE" | jq '[.[] | select(.mergeable == null)] | length')
+
+            if [[ "$NULL_COUNT" -eq 0 ]]; then
+              echo "All PRs have computed mergeable status."
+              break
+            fi
+
+            if [[ "$attempt" -lt 3 ]]; then
+              echo "$NULL_COUNT PR(s) still computing mergeable status, waiting..."
+              sleep 10
+            fi
+          done
+
+          if [[ -z "$PENDING_PRS" ]]; then
+            echo "No conflicted release PRs found."
+            exit 0
+          fi
+
+          echo "Found conflicted release PRs: $PENDING_PRS"
+
+          for pr in $PENDING_PRS; do
+            echo "Adding autorebase label to PR #$pr..."
+            gh pr edit "$pr" --add-label "autorebase" --repo ${{ github.repository }} || true
+          done
+
+          echo "### 🔄 Triggered Rebase for Conflicted Release PRs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          for pr in $PENDING_PRS; do
+            echo "- PR #$pr" >> $GITHUB_STEP_SUMMARY
+          done

--- a/scripts/validate-commit-message.py
+++ b/scripts/validate-commit-message.py
@@ -36,10 +36,16 @@ from pathlib import Path
 
 # Valid component scopes from release-please-config.json
 VALID_SCOPES = {
-    "operator",
+    "operator",  # Legacy alias for operator-image
+    "operator-image",
     "chart-operator",
     "chart-realm",
     "chart-client",
+}
+
+# Scopes that are aliases of each other (cannot be combined)
+SCOPE_ALIASES = {
+    frozenset({"operator", "operator-image"}),
 }
 
 # Commit types that trigger releases and REQUIRE a scope
@@ -86,6 +92,16 @@ def validate_scope(scope: str | None) -> tuple[bool, str]:
             f"Invalid scope components: {', '.join(invalid_components)}\n"
             f"Valid scopes: {', '.join(sorted(VALID_SCOPES))}"
         )
+
+    # Check for alias conflicts (e.g., operator+operator-image)
+    components_set = set(components)
+    for alias_group in SCOPE_ALIASES:
+        overlap = components_set & alias_group
+        if len(overlap) > 1:
+            return False, (
+                f"Cannot combine aliased scopes: {', '.join(sorted(overlap))}\n"
+                f"These scopes refer to the same component. Use only one."
+            )
 
     # Check if components are in alphabetical order (for consistency)
     sorted_components = sorted(components)


### PR DESCRIPTION
## Summary

This PR addresses several improvements to the release process:

### 1. Auto-rebase for conflicted release PRs

With `separate-pull-requests: true`, when multiple components have pending release PRs, merging one creates manifest conflicts in the others.

**Solution:** Added `rebase-release-prs.yml` workflow that:
- Runs on every push to main
- Finds release PRs with `autorelease: pending` label that have conflicts
- Adds `autorebase` label to trigger the existing `auto-rebase.yml` workflow

### 2. Improved tagging scheme

**All components now use `include-component-in-tag: true`:**
- `operator-image-v0.4.5` - Docker image releases
- `chart-operator-v0.3.3` - Operator Helm chart releases
- `chart-realm-v0.3.1` - Realm Helm chart releases
- `chart-client-v0.3.1` - Client Helm chart releases

**Primary version tag:** When `chart-operator` is released, we also create a `v{version}` tag pointing to the same commit. This makes `chart-operator` the "primary" version that users track.

### 3. Explicit path exclusions

Added `exclude-paths` to the operator-image package to explicitly prevent chart-only changes from triggering Docker image releases:
```json
"exclude-paths": [
  "charts/keycloak-operator",
  "charts/keycloak-realm", 
  "charts/keycloak-client"
]
```

### 4. Component rename

Changed component name from `operator` to `operator-image` for clarity:
- Release PR titles: `chore(main): release operator-image 0.4.5`
- Tags: `operator-image-v0.4.5`

## Tag Structure After This Change

| Component | Example Tag | Additional Tags |
|-----------|-------------|-----------------|
| Docker Image | `operator-image-v0.4.5` | - |
| Operator Chart | `chart-operator-v0.3.3` | `v0.3.3` (primary) |
| Realm Chart | `chart-realm-v0.3.1` | - |
| Client Chart | `chart-client-v0.3.1` | - |

The `v{version}` tag on chart-operator releases allows users to reference the "main" project version without needing to know the chart prefix.