### PR TITLE
docs: fix documentation issues from user feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ Get a complete Keycloak setup running in under 10 minutes:
 
 ```bash
 # 1. Install the operator (OCI registry)
+# Note: The chart creates the namespace by default, don't use --create-namespace
 helm install keycloak-operator \
   oci://ghcr.io/vriesdemichael/charts/keycloak-operator \
-  --namespace keycloak-system --create-namespace
+  --namespace keycloak-system
 
 # Or install from local charts:
 # helm install keycloak-operator ./charts/keycloak-operator \
-#   --namespace keycloak-system --create-namespace
+#   --namespace keycloak-system
 
 # 2. Deploy Keycloak with database
 kubectl apply -f examples/01-keycloak-instance.yaml
@@ -30,7 +31,7 @@ kubectl apply -f examples/01-keycloak-instance.yaml
 # 3. Create an identity realm
 kubectl apply -f examples/02-realm-example.yaml
 
-# 5. Create an OAuth2 client
+# 4. Create an OAuth2 client
 kubectl apply -f examples/03-client-example.yaml
 ```
 

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -8,8 +8,20 @@ Before you begin, ensure you have:
 
 - ✅ Kubernetes cluster (v1.26+)
 - ✅ `kubectl` configured to access your cluster
-- ✅ [Helm 3](https://helm.sh/docs/intro/install/) installed
+- ✅ [Helm 3.8+](https://helm.sh/docs/intro/install/) installed (required for OCI registry support)
 - ✅ Cluster admin permissions (for CRD installation)
+
+### Storage Class Configuration
+
+If using CloudNativePG for the database, ensure your cluster has a suitable StorageClass:
+
+```bash
+# Check available storage classes
+kubectl get storageclass
+
+# If your cluster doesn't have a 'standard' storageClass, configure it during install:
+--set keycloak.database.cnpg.storage.storageClass=<your-storage-class>
+```
 
 ## The 3-Helm-Chart Approach
 
@@ -46,20 +58,19 @@ The Keycloak operator chart can create the PostgreSQL cluster automatically usin
 Install the operator with Keycloak instance enabled:
 
 ```bash
-# Add the keycloak-operator Helm repository
-helm repo add keycloak-operator https://vriesdemichael.github.io/keycloak-operator
-helm repo update
-
-# Install operator + Keycloak with CloudNativePG database
-helm install keycloak-operator keycloak-operator/keycloak-operator \
+# Install operator + Keycloak with CloudNativePG database (using OCI registry)
+helm install keycloak-operator oci://ghcr.io/vriesdemichael/charts/keycloak-operator \
   --namespace keycloak-system \
-  --create-namespace \
   --set keycloak.enabled=true \
   --set keycloak.database.cnpg.enabled=true \
   --set keycloak.database.cnpg.clusterName=keycloak-postgres \
   --set keycloak.replicas=3 \
   --wait
 ```
+
+> **Note: Namespace Creation**
+> The chart creates the namespace by default (`namespace.create=true`). Do not use `--create-namespace` flag with the default settings.
+> If you prefer to create the namespace yourself, set `--set namespace.create=false` and use `--create-namespace`.
 
 **What this installs:**
 - ✅ Keycloak operator (2 replicas for HA)
@@ -90,9 +101,9 @@ kubectl get cluster -n keycloak-system
 If you have an existing PostgreSQL database:
 
 ```bash
-helm install keycloak-operator keycloak-operator/keycloak-operator \
+helm install keycloak-operator oci://ghcr.io/vriesdemichael/charts/keycloak-operator \
   --namespace keycloak-system \
-  --create-namespace \
+  --set namespace.create=false \
   --set keycloak.enabled=true \
   --set keycloak.database.host=postgresql.database.svc \
   --set keycloak.database.port=5432 \
@@ -111,7 +122,7 @@ Create a realm for your application using the realm Helm chart:
 kubectl create namespace my-app
 
 # Install realm chart
-helm install my-app-realm keycloak-operator/keycloak-realm \
+helm install my-app-realm oci://ghcr.io/vriesdemichael/charts/keycloak-realm \
   --namespace my-app \
   --set realmName=my-app \
   --set displayName="My Application" \
@@ -145,7 +156,7 @@ kubectl get keycloakrealm -n my-app
 Create an OAuth2/OIDC client for your application:
 
 ```bash
-helm install my-app-client keycloak-operator/keycloak-client \
+helm install my-app-client oci://ghcr.io/vriesdemichael/charts/keycloak-client \
   --namespace my-app \
   --set clientId=my-app \
   --set name="My Application" \
@@ -317,9 +328,9 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://vriesdemichael.github.io/keycloak-operator
+    repoURL: ghcr.io/vriesdemichael/charts
     chart: keycloak-operator
-    targetRevision: 0.2.x
+    targetRevision: 0.3.x
     helm:
       values: |
         keycloak:
@@ -390,7 +401,7 @@ kubectl get keycloakrealm my-app-realm -n my-app \
   -o jsonpath='{.spec.clientAuthorizationGrants}' | jq
 
 # Add your namespace to the grant list
-helm upgrade my-app-realm keycloak-operator/keycloak-realm \
+helm upgrade my-app-realm oci://ghcr.io/vriesdemichael/charts/keycloak-realm \
   --namespace my-app \
   --reuse-values \
   --set 'clientAuthorizationGrants={my-app,my-new-namespace}'

--- a/examples/02-realm-example.yaml
+++ b/examples/02-realm-example.yaml
@@ -38,8 +38,8 @@ spec:
     # Enable remember me functionality
     rememberMe: true
 
-  # Session settings
-  sessions:
+  # Token and session settings
+  tokenSettings:
     # SSO session timeout (30 minutes)
     ssoSessionIdleTimeout: 1800
 


### PR DESCRIPTION
## Summary
Fixes several documentation issues identified from user feedback.

## Changes
- **Fix Helm repo URLs to use OCI registry** (#234): Replace non-existent GitHub Pages helm repo URL with working OCI registry `oci://ghcr.io/vriesdemichael/charts/keycloak-operator`
- **Add storageClass documentation** (#238): Added prerequisites section explaining how to check and configure storageClass for CNPG
- **Fix example field names** (#239): Changed `sessions:` to `tokenSettings:` in `examples/02-realm-example.yaml` - the sessions field doesn't exist in the CRD
- **Clarify namespace creation** (#236): Documented that the chart creates the namespace by default (`namespace.create=true`), so users should not use `--create-namespace` flag

## Additional fixes
- Updated ArgoCD example to use OCI registry
- Fixed step numbering in README (was 1,2,3,5 → now 1,2,3,4)

## Closes
- #234 - Helm Repository URL returns 404
- #236 - Clarify namespace creation behavior in documentation
- #238 - Quickstart should document storageClass configuration for CNPG
- #239 - Example uses wrong field names (sessions vs tokenSettings)