### PR TITLE
fix(chart-operator): add missing ClusterRoleBinding for namespace-access

### DIFF
--- a/charts/keycloak-operator/templates/02_rbac.yaml
+++ b/charts/keycloak-operator/templates/02_rbac.yaml
@@ -265,4 +265,27 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "keycloak-operator.serviceAccountName" . }}
   namespace: {{ include "keycloak-operator.namespace" . }}
+
+---
+# ClusterRoleBinding for cross-namespace access (realms/clients in other namespaces)
+# This grants the operator permission to manage resources in any namespace
+# that creates KeycloakRealm or KeycloakClient resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "keycloak-operator.fullname" . }}-namespace-access
+  labels:
+    {{- include "keycloak-operator.labels" . | nindent 4 }}
+  {{- with include "keycloak-operator.annotations" . }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "keycloak-operator.fullname" . }}-namespace-access
+subjects:
+- kind: ServiceAccount
+  name: {{ include "keycloak-operator.serviceAccountName" . }}
+  namespace: {{ include "keycloak-operator.namespace" . }}
 {{- end }}


### PR DESCRIPTION
## Summary
Adds the missing ClusterRoleBinding for the `namespace-access` ClusterRole, fixing cross-namespace client creation.

## Problem
The ClusterRole `keycloak-operator-namespace-access` was defined with the correct permissions for:
- Managing KeycloakRealm/KeycloakClient resources in any namespace
- Creating/updating client credential secrets in application namespaces
- Reading labeled secrets for password references

However, there was **no ClusterRoleBinding** to grant these permissions to the operator's service account. This caused errors like:

```
User "system:serviceaccount:keycloak-system:keycloak-operator-keycloak-system"
cannot patch resource "secrets" in API group "" in the namespace "my-app"
```

## Solution
Added a ClusterRoleBinding that binds the `namespace-access` ClusterRole to the operator's service account, granting it the permissions needed for cross-namespace operations.

## RBAC Structure After Fix
| Resource | Type | Purpose |
|----------|------|---------|
| `*-core` | ClusterRole + ClusterRoleBinding | Watching CRDs cluster-wide, leader election |
| `*-manager` | Role + RoleBinding | Managing resources in operator namespace |
| `*-namespace-access` | ClusterRole + **ClusterRoleBinding** ✅ | Cross-namespace secret/CRD management |

## Closes
#235