### PR TITLE
fix(chart-operator): align helm ingress values with keycloak CRD schema

### DIFF
--- a/charts/examples/operator-values.yaml
+++ b/charts/examples/operator-values.yaml
@@ -69,15 +69,10 @@ keycloak:
     className: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-prod
-    hosts:
-      - host: keycloak.example.com
-        paths:
-          - path: /
-            pathType: Prefix
-    tls:
-      - secretName: keycloak-tls
-        hosts:
-          - keycloak.example.com
+    host: keycloak.example.com
+    path: /
+    tlsEnabled: true
+    tlsSecretName: keycloak-tls
 
   resources:
     limits:

--- a/charts/keycloak-operator/README.md
+++ b/charts/keycloak-operator/README.md
@@ -216,8 +216,10 @@ The chart can optionally deploy a Keycloak instance:
 | `keycloak.ingress.enabled` | Enable ingress | `false` |
 | `keycloak.ingress.className` | Ingress class name | `""` |
 | `keycloak.ingress.annotations` | Ingress annotations | `{}` |
-| `keycloak.ingress.hosts` | Ingress hosts | See [values.yaml](values.yaml) |
-| `keycloak.ingress.tls` | Ingress TLS configuration | `[]` |
+| `keycloak.ingress.host` | Ingress hostname | `keycloak.example.com` |
+| `keycloak.ingress.path` | Ingress path | `/` |
+| `keycloak.ingress.tlsEnabled` | Enable TLS for ingress | `true` |
+| `keycloak.ingress.tlsSecretName` | Secret containing TLS certificate | `""` |
 | `keycloak.resources` | Keycloak resource limits/requests | See [values.yaml](values.yaml) |
 
 **Example:** Deploy Keycloak with CloudNativePG:
@@ -365,15 +367,10 @@ keycloak:
     className: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-prod
-    hosts:
-      - host: keycloak.example.com
-        paths:
-          - path: /
-            pathType: Prefix
-    tls:
-      - secretName: keycloak-tls
-        hosts:
-          - keycloak.example.com
+    host: keycloak.example.com
+    path: /
+    tlsEnabled: true
+    tlsSecretName: keycloak-tls
 ```
 
 ```bash

--- a/charts/keycloak-operator/templates/05_keycloak_cr.yaml
+++ b/charts/keycloak-operator/templates/05_keycloak_cr.yaml
@@ -46,13 +46,11 @@ spec:
     annotations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.keycloak.ingress.hosts }}
-    hosts:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- with .Values.keycloak.ingress.tls }}
-    tls:
-      {{- toYaml . | nindent 6 }}
+    host: {{ .Values.keycloak.ingress.host }}
+    path: {{ .Values.keycloak.ingress.path | default "/" }}
+    tlsEnabled: {{ .Values.keycloak.ingress.tlsEnabled | default true }}
+    {{- with .Values.keycloak.ingress.tlsSecretName }}
+    tlsSecretName: {{ . }}
     {{- end }}
   {{- end }}
 

--- a/charts/keycloak-operator/values.schema.json
+++ b/charts/keycloak-operator/values.schema.json
@@ -597,38 +597,23 @@
                 "type": "string"
               }
             },
-            "hosts": {
-              "type": "array",
-              "description": "Ingress hosts",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "host": {
-                    "type": "string"
-                  },
-                  "paths": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "path": {
-                          "type": "string"
-                        },
-                        "pathType": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+            "host": {
+              "type": "string",
+              "description": "Ingress hostname"
             },
-            "tls": {
-              "type": "array",
-              "description": "TLS configuration",
-              "items": {
-                "type": "object"
-              }
+            "path": {
+              "type": "string",
+              "description": "Ingress path",
+              "default": "/"
+            },
+            "tlsEnabled": {
+              "type": "boolean",
+              "description": "Enable TLS for ingress",
+              "default": true
+            },
+            "tlsSecretName": {
+              "type": "string",
+              "description": "Secret containing TLS certificate"
             }
           }
         },

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -478,20 +478,23 @@ keycloak:
     #   nginx.ingress.kubernetes.io/ssl-redirect: "true"
     annotations: {}
 
-    # Hosts and paths configuration
-    hosts:
-      - host: keycloak.example.com
-        paths:
-          - path: /
-            pathType: Prefix
+    # Ingress hostname
+    # The hostname for the Keycloak ingress
+    # Example: "keycloak.example.com"
+    host: keycloak.example.com
 
-    # TLS configuration
-    # Example:
-    # tls:
-    #   - secretName: keycloak-tls
-    #     hosts:
-    #       - keycloak.example.com
-    tls: []
+    # Ingress path
+    # The path for the Keycloak ingress
+    path: /
+
+    # Enable TLS for ingress
+    # When enabled, the ingress will use HTTPS
+    tlsEnabled: true
+
+    # TLS secret name
+    # Secret containing TLS certificate and key
+    # Example: "keycloak-tls"
+    tlsSecretName: ""
 
   # Resource limits for Keycloak pods
   # Adjust based on load and number of users


### PR DESCRIPTION
## Summary

Fixes a mismatch between the Helm chart values and the Keycloak CRD ingress schema.

## Problem

The Helm chart `values.yaml` used a Kubernetes-style ingress configuration with:
- `hosts` (array of host objects with nested `paths` arrays)
- `tls` (array of TLS configurations)

However, the Keycloak CRD (`keycloak-crd.yaml`) and Pydantic model (`keycloak.py`) define ingress with:
- `host` (singular string)
- `path` (singular string)
- `tlsEnabled` (boolean)
- `tlsSecretName` (string)

This mismatch meant that when users enabled ingress via Helm values, the generated Keycloak CR would have invalid fields (`hosts` instead of `host`, etc.) that don't match the CRD schema.

## Solution

Updated the Helm chart to use the singular field names that match the CRD:

**Before (values.yaml):**
```yaml
keycloak:
  ingress:
    enabled: true
    hosts:
      - host: keycloak.example.com
        paths:
          - path: /
            pathType: Prefix
    tls:
      - secretName: keycloak-tls
        hosts:
          - keycloak.example.com
```

**After (values.yaml):**
```yaml
keycloak:
  ingress:
    enabled: true
    host: keycloak.example.com
    path: /
    tlsEnabled: true
    tlsSecretName: keycloak-tls
```

## Changes

- `charts/keycloak-operator/values.yaml` - Updated ingress section to use singular fields
- `charts/keycloak-operator/values.schema.json` - Updated schema to match
- `charts/keycloak-operator/templates/05_keycloak_cr.yaml` - Updated template to output correct fields
- `charts/keycloak-operator/README.md` - Updated documentation
- `charts/examples/operator-values.yaml` - Updated example

## Testing

- All unit and integration tests pass
- Helm lint passes
- Template output verified to produce valid Keycloak CR ingress spec