### PR TITLE
feat(operator): add quiet logging mode for health probes and webhooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,6 +463,34 @@ KEYCLOAK_API_NAMESPACE_BURST=10             # Per-namespace burst capacity
 RECONCILE_JITTER_MAX_SECONDS=5.0            # Random delay to prevent thundering herd
 ```
 
+## Logging Configuration
+
+The operator provides fine-grained logging control to reduce noise during debugging.
+
+### Environment Variables
+
+```bash
+LOG_LEVEL=INFO                    # Main log level (DEBUG, INFO, WARNING, ERROR)
+JSON_LOGS=true                    # Enable JSON structured logging
+CORRELATION_IDS=true              # Enable request correlation IDs
+LOG_HEALTH_PROBES=false           # Log health/readiness probe requests (default: false)
+WEBHOOK_LOG_LEVEL=WARNING         # Log level for admission webhooks (default: WARNING)
+```
+
+### Quiet Mode for Debugging
+
+By default, the operator suppresses noisy log messages:
+- **Health probes**: `/healthz`, `/health`, `/ready`, `/metrics` endpoints are NOT logged
+- **Webhooks**: Admission webhook requests are logged at WARNING level (errors only)
+- **aiohttp access logs**: Suppressed to avoid spamming with probe requests
+
+To enable verbose logging for debugging specific components:
+```bash
+LOG_HEALTH_PROBES=true            # Log all probe requests
+WEBHOOK_LOG_LEVEL=DEBUG           # Log all webhook requests including successful validations
+LOG_LEVEL=DEBUG                   # Enable debug logging for all components
+```
+
 ### Async Pattern
 
 All Keycloak API interactions are now fully async:

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -137,16 +137,19 @@ operator:
 
   # Environment variables for operator customization
   # Common variables:
-  # - KEYCLOAK_OPERATOR_LOG_LEVEL: DEBUG, INFO, WARNING, ERROR (default: INFO)
-  # - KEYCLOAK_OPERATOR_JSON_LOGS: "true" for JSON structured logs (default: "false")
-  # - KEYCLOAK_OPERATOR_WORKERS: Number of concurrent reconciliation workers (default: 10)
+  # - LOG_LEVEL: DEBUG, INFO, WARNING, ERROR (default: INFO)
+  # - JSON_LOGS: "true" for JSON structured logs (default: "true")
+  # - LOG_HEALTH_PROBES: "true" to log health/ready probe requests (default: "false")
+  # - WEBHOOK_LOG_LEVEL: Log level for webhook handlers (default: "WARNING")
   env: []
-    # - name: KEYCLOAK_OPERATOR_LOG_LEVEL
+    # - name: LOG_LEVEL
     #   value: "INFO"
-    # - name: KEYCLOAK_OPERATOR_JSON_LOGS
+    # - name: JSON_LOGS
     #   value: "true"
-    # - name: KEYCLOAK_OPERATOR_WORKERS
-    #   value: "10"
+    # - name: LOG_HEALTH_PROBES
+    #   value: "false"
+    # - name: WEBHOOK_LOG_LEVEL
+    #   value: "WARNING"
 
 # ============================================================================
 # Namespace Configuration

--- a/src/keycloak_operator/operator.py
+++ b/src/keycloak_operator/operator.py
@@ -68,6 +68,8 @@ def configure_logging() -> None:
         log_level=operator_settings.log_level.upper(),
         enable_json_formatting=operator_settings.json_logs,
         correlation_id_enabled=operator_settings.correlation_ids,
+        log_health_probes=operator_settings.log_health_probes,
+        webhook_log_level=operator_settings.webhook_log_level,
     )
 
 

--- a/src/keycloak_operator/settings.py
+++ b/src/keycloak_operator/settings.py
@@ -73,6 +73,16 @@ class Settings(BaseSettings):
         validation_alias="CORRELATION_IDS",
         description="Enable correlation IDs in logs for request tracing",
     )
+    log_health_probes: bool = Field(
+        default=False,
+        validation_alias="LOG_HEALTH_PROBES",
+        description="Log health/readiness probe requests (disabled by default to reduce noise)",
+    )
+    webhook_log_level: str = Field(
+        default="WARNING",
+        validation_alias="WEBHOOK_LOG_LEVEL",
+        description="Log level for webhook requests (DEBUG, INFO, WARNING, ERROR)",
+    )
 
     # Namespace watching
     namespaces: str = Field(


### PR DESCRIPTION
## Summary

Adds fine-grained logging control to reduce log noise during debugging. The operator was spamming logs with health check probes and webhook requests, making it difficult to find actual operator activity.

## Problem

During debugging, the logs are flooded with:
- Health probe requests (`/healthz`, `/health`, `/ready`) every few seconds from Kubernetes
- Metrics scrape requests (`/metrics`) from Prometheus
- Webhook validation requests for every CR create/update

This makes it extremely difficult to find and follow actual reconciliation activity.

## Solution

Added two new environment variables to control logging verbosity:

| Variable | Default | Description |
|----------|---------|-------------|
| `LOG_HEALTH_PROBES` | `false` | Log health/readiness probe requests |
| `WEBHOOK_LOG_LEVEL` | `WARNING` | Log level for admission webhook handlers |

### Default Behavior (Quiet Mode)
- Health probe endpoints are **NOT logged** (filtered out)
- Webhook handlers only log at WARNING level (errors only)
- aiohttp access logs are suppressed

### Verbose Mode for Debugging
```bash
LOG_HEALTH_PROBES=true           # Log all probe requests
WEBHOOK_LOG_LEVEL=DEBUG          # Log all webhook activity
LOG_LEVEL=DEBUG                  # Enable debug for everything
```

## Implementation Details

- Added `HealthProbeFilter` class in `logging.py` that filters log messages containing probe endpoint paths
- Suppressed aiohttp access/server/web loggers at WARNING level
- Added webhook-specific logger level configuration
- Updated Helm chart `values.yaml` with documentation of new env vars
- Updated `CLAUDE.md` with new "Logging Configuration" section

## Changes

- `src/keycloak_operator/settings.py` - Added `log_health_probes` and `webhook_log_level` settings
- `src/keycloak_operator/observability/logging.py` - Added `HealthProbeFilter` and updated `setup_structured_logging()`
- `src/keycloak_operator/operator.py` - Pass new settings to logging setup
- `charts/keycloak-operator/values.yaml` - Document new environment variables
- `CLAUDE.md` - Document logging configuration

## Testing

- All unit and integration tests pass
- Coverage at 58%