### PR TITLE
fix(operator): use correct Keycloak CR name in health check timers

### DIFF
--- a/src/keycloak_operator/handlers/realm.py
+++ b/src/keycloak_operator/handlers/realm.py
@@ -359,9 +359,12 @@ async def monitor_realm_health(
         # Get admin client and verify connection
         operator_ref = realm_spec.operator_ref
         target_namespace = operator_ref.namespace or namespace
+        # Use hardcoded Keycloak CR name - consistent with realm_reconciler.py
+        # The 'name' parameter here is the KeycloakRealm's metadata.name, NOT the Keycloak CR name
+        keycloak_name = "keycloak"
 
         async with await get_keycloak_admin_client(
-            name, target_namespace
+            keycloak_name, target_namespace
         ) as admin_client:
             # Check if realm exists in Keycloak
             realm_name = realm_spec.realm_name


### PR DESCRIPTION
## Summary

Fixes a bug where health check timer handlers incorrectly looked up Keycloak CRs using the realm/client name instead of the actual Keycloak CR name, causing 404 errors in multi-namespace GitOps setups.

## Problem

The health check timer handlers were passing the **realm/client resource name** to `get_keycloak_admin_client()` instead of the **Keycloak CR name**.

### Log Evidence

```json
{
  "message": "Creating admin client for Keycloak argocd-realm in keycloak"
}
```

Followed by:

```json
{
  "message": "Failed to create admin client: (404)\nReason: Not Found",
  "HTTP response body": {
    "message": "keycloaks.vriesdemichael.github.io \"argocd-realm\" not found"
  }
}
```

### Root Cause

In `handlers/realm.py` line 363-364 (before fix):
```python
async with await get_keycloak_admin_client(
    name, target_namespace  # BUG: 'name' is KeycloakRealm metadata.name
) as admin_client:
```

In `handlers/client.py` line 370-371 (before fix):
```python
async with await get_keycloak_admin_client(
    realm_ref.name, realm_namespace  # BUG: realm_ref.name is KeycloakRealm name
) as admin_client:
```

### Why This Only Appeared in Multi-Namespace Setups

The bug only manifests when:
1. Realm `metadata.name` ≠ `keycloak` (the hardcoded CR name)
2. Resources are in different namespaces

In single-namespace setups where everything is together and realms might be named `keycloak`, the bug was hidden.

## Solution

### Realm Handler Fix
Use the hardcoded `keycloak` name, consistent with `realm_reconciler.py`:

```python
keycloak_name = "keycloak"
async with await get_keycloak_admin_client(
    keycloak_name, target_namespace
) as admin_client:
```

### Client Handler Fix
Properly resolve the Keycloak instance through the realm's status:

1. Fetch the KeycloakRealm resource
2. Get `actual_realm_name` from `spec.realmName`
3. Parse `keycloakInstance` from status (format: `namespace/name`)
4. Use the resolved `keycloak_namespace` and `keycloak_name`

This matches how `client_reconciler.py` handles it via `_get_realm_info()`.

## Testing

- All unit and integration tests pass
- Coverage at 58%

## Impact

This fix ensures:
- Health checks no longer fail with 404 errors in multi-namespace setups
- Realms won't be incorrectly marked as "Degraded" due to health check failures
- No more alarming error logs during every reconciliation cycle

## Related Bug Report

This was reported as BUG 3 in a comprehensive bug report:
> "The operator tries to look up a Keycloak CR using the realm name instead of following the proper reference chain through operatorRef"

The user provided excellent reproduction steps and log evidence that helped identify the exact issue.