### PR TITLE
fix(chart-operator): update for operator v0.5.8

### DIFF
--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: keycloak-operator
 description: A Helm chart for deploying the Keycloak Operator with GitOps compatibility
 type: application
 version: 0.3.7
-appVersion: "v0.5.7"
+appVersion: "v0.5.8"
 keywords:
   - keycloak
   - operator

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -34,7 +34,7 @@ operator:
     # Overrides the image tag whose default is the chart appVersion.
     # This is automatically updated by the update-chart-versions workflow on new releases
     # Example: "v0.3.2" or "latest"
-    tag: "v0.5.7"
+    tag: "v0.5.8"
 
   # Image pull secrets for private registries
   # Example:


### PR DESCRIPTION
Updates operator chart to use operator version `v0.5.8`.

**Changes:**
- Updated `charts/keycloak-operator/values.yaml` image tag
- Updated `charts/keycloak-operator/Chart.yaml` appVersion

This fix ensures the chart is compatible with operator v0.5.8.

🤖 Auto-generated by CI/CD workflow