### PR TITLE
ci: use PAT for rebase workflow to trigger CI checks

### DIFF
--- a/.github/workflows/rebase-release-prs.yml
+++ b/.github/workflows/rebase-release-prs.yml
@@ -7,6 +7,7 @@ name: Rebase Conflicted Release PRs
 on:
   push:
     branches: [main]
+  workflow_dispatch:  # Allow manual triggering
 
 permissions:
   contents: write
@@ -21,7 +22,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT to ensure pushed changes trigger CI workflows
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -31,7 +33,7 @@ jobs:
       - name: Check for conflicted release PRs
         id: check-conflicts
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           echo "Checking for conflicted release PRs..."
 
@@ -82,7 +84,7 @@ jobs:
       - name: Rebase and resolve conflicts
         if: steps.check-conflicts.outputs.has_conflicts == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           RESOLVED_PRS=""
           FAILED_PRS=""


### PR DESCRIPTION
## Follow-up to #269

This fixes two issues with the rebase workflow:

1. **Use PAT instead of GITHUB_TOKEN** - Pushes made with `GITHUB_TOKEN` don't trigger other workflows (GitHub's anti-infinite-loop protection). Using `RELEASE_PLEASE_TOKEN` ensures CI checks run on rebased PRs.

2. **Add `workflow_dispatch`** - Allows manual triggering of the workflow if it doesn't get picked up automatically by CI/CD.