### PR TITLE
fix(operator): resolve ingress hostname bug and improve type safety

### DIFF
--- a/.github/workflows/rebase-release-prs.yml
+++ b/.github/workflows/rebase-release-prs.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # Use PAT to ensure pushed changes trigger CI workflows
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/src/keycloak_operator/models/client.py
+++ b/src/keycloak_operator/models/client.py
@@ -10,6 +10,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from keycloak_operator.models.types import (
+    KeycloakConfigMap,
+    KubernetesMetadata,
+)
+
 
 class RealmRef(BaseModel):
     """Reference to a parent KeycloakRealm."""
@@ -34,7 +39,7 @@ class KeycloakClientProtocolMapper(BaseModel):
     name: str = Field(..., description="Mapper name")
     protocol: str = Field("openid-connect", description="Protocol type")
     protocol_mapper: str = Field(..., alias="protocolMapper", description="Mapper type")
-    config: dict[str, Any] = Field(
+    config: KeycloakConfigMap = Field(
         default_factory=dict, description="Mapper configuration"
     )
 
@@ -564,7 +569,7 @@ class KeycloakClient(BaseModel):
 
     api_version: str = Field("vriesdemichael.github.io/v1", alias="apiVersion")
     kind: str = Field("KeycloakClient")
-    metadata: dict[str, Any] = Field(..., description="Kubernetes metadata")
+    metadata: KubernetesMetadata = Field(..., description="Kubernetes metadata")
     spec: KeycloakClientSpec = Field(..., description="Client specification")
     status: KeycloakClientStatus | None = Field(
         None, description="Client status (managed by operator)"

--- a/src/keycloak_operator/models/keycloak.py
+++ b/src/keycloak_operator/models/keycloak.py
@@ -6,9 +6,14 @@ and status. These models ensure proper validation and provide IDE support
 for the operator development.
 """
 
-from typing import Any
-
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+from keycloak_operator.models.types import (
+    KubernetesMetadata,
+    KubernetesProbeConfig,
+    KubernetesSecurityContext,
+    OperationalStats,
+)
 
 
 class SecretReference(BaseModel):
@@ -336,7 +341,7 @@ class KeycloakSpec(BaseModel):
     )
 
     # Operational settings
-    startup_probe: dict[str, Any] = Field(
+    startup_probe: KubernetesProbeConfig = Field(
         default_factory=lambda: {
             "httpGet": {"path": "/health/started", "port": 9000},
             "initialDelaySeconds": 30,
@@ -347,7 +352,7 @@ class KeycloakSpec(BaseModel):
         alias="startupProbe",
         description="Startup probe configuration",
     )
-    liveness_probe: dict[str, Any] = Field(
+    liveness_probe: KubernetesProbeConfig = Field(
         default_factory=lambda: {
             "httpGet": {"path": "/health/live", "port": 9000},
             "initialDelaySeconds": 60,
@@ -358,7 +363,7 @@ class KeycloakSpec(BaseModel):
         alias="livenessProbe",
         description="Liveness probe configuration",
     )
-    readiness_probe: dict[str, Any] = Field(
+    readiness_probe: KubernetesProbeConfig = Field(
         default_factory=lambda: {
             "httpGet": {"path": "/health/ready", "port": 9000},
             "initialDelaySeconds": 30,
@@ -371,12 +376,12 @@ class KeycloakSpec(BaseModel):
     )
 
     # Security and RBAC
-    pod_security_context: dict[str, Any] = Field(
+    pod_security_context: KubernetesSecurityContext = Field(
         default_factory=dict,
         alias="podSecurityContext",
         description="Pod security context",
     )
-    security_context: dict[str, Any] = Field(
+    security_context: KubernetesSecurityContext = Field(
         default_factory=dict,
         alias="securityContext",
         description="Container security context",
@@ -533,7 +538,7 @@ class KeycloakStatus(BaseModel):
     )
 
     # Statistics (optional)
-    stats: dict[str, Any] = Field(
+    stats: OperationalStats = Field(
         default_factory=dict, description="Operational statistics"
     )
 
@@ -548,7 +553,7 @@ class Keycloak(BaseModel):
 
     api_version: str = Field("vriesdemichael.github.io/v1", alias="apiVersion")
     kind: str = Field("Keycloak")
-    metadata: dict[str, Any] = Field(..., description="Kubernetes metadata")
+    metadata: KubernetesMetadata = Field(..., description="Kubernetes metadata")
     spec: KeycloakSpec = Field(..., description="Keycloak specification")
     status: KeycloakStatus | None = Field(
         None, description="Keycloak status (managed by operator)"

--- a/src/keycloak_operator/models/realm.py
+++ b/src/keycloak_operator/models/realm.py
@@ -10,6 +10,12 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from keycloak_operator.models.types import (
+    AuthenticationExecutionList,
+    KeycloakConfigMap,
+    KubernetesMetadata,
+)
+
 
 class OperatorRef(BaseModel):
     """Reference to the operator managing this realm."""
@@ -147,7 +153,7 @@ class KeycloakIdentityProvider(BaseModel):
     enabled: bool = Field(True, description="Whether the provider is enabled")
 
     # Provider-specific configuration
-    config: dict[str, Any] = Field(
+    config: KeycloakConfigMap = Field(
         default_factory=dict, description="Provider-specific configuration"
     )
 
@@ -220,7 +226,7 @@ class KeycloakUserFederation(BaseModel):
     enabled: bool = Field(True, description="Whether federation is enabled")
 
     # Provider-specific configuration
-    config: dict[str, Any] = Field(
+    config: KeycloakConfigMap = Field(
         default_factory=dict, description="Federation-specific configuration"
     )
 
@@ -250,7 +256,7 @@ class KeycloakAuthenticationFlow(BaseModel):
     built_in: bool = Field(False, description="Whether this is a built-in flow")
 
     # Flow executions
-    authentication_executions: list[dict[str, Any]] = Field(
+    authentication_executions: AuthenticationExecutionList = Field(
         default_factory=list, description="Authentication executions"
     )
 
@@ -895,7 +901,7 @@ class KeycloakRealm(BaseModel):
 
     api_version: str = Field("vriesdemichael.github.io/v1", alias="apiVersion")
     kind: str = Field("KeycloakRealm")
-    metadata: dict[str, Any] = Field(..., description="Kubernetes metadata")
+    metadata: KubernetesMetadata = Field(..., description="Kubernetes metadata")
     spec: KeycloakRealmSpec = Field(..., description="Realm specification")
     status: KeycloakRealmStatus | None = Field(
         None, description="Realm status (managed by operator)"

--- a/src/keycloak_operator/models/types.py
+++ b/src/keycloak_operator/models/types.py
@@ -1,0 +1,112 @@
+"""
+Type aliases for structural typing in Keycloak operator models.
+
+This module defines type aliases that provide semantic clarity about the
+expected structure of dynamic fields, without being overly restrictive.
+
+Categories:
+- Keycloak API types: Flat string-to-string mappings (Keycloak REST API convention)
+- Kubernetes types: Nested structures from K8s API
+- Operational types: Runtime data with truly dynamic structure
+"""
+
+from typing import Any
+
+# =============================================================================
+# Keycloak API Types
+# =============================================================================
+# Keycloak's REST API uses flat string-to-string mappings for all config blocks.
+# Even boolean and numeric values are represented as strings:
+#   - "multivalued": "true" (not True)
+#   - "priority": "10" (not 10)
+#   - "claim.name": "email"
+
+type KeycloakConfigMap = dict[str, str]
+"""
+Flat string-to-string configuration map used by Keycloak REST API.
+
+Used for:
+- Protocol mapper configurations
+- Identity provider configurations
+- User federation configurations
+- Client attribute configurations
+"""
+
+# =============================================================================
+# Kubernetes API Types
+# =============================================================================
+# Kubernetes objects have nested structures. We use Any for deep nesting
+# but the type alias communicates the expected structure category.
+
+type KubernetesProbeConfig = dict[str, Any]
+"""
+Kubernetes probe configuration (startup, liveness, readiness).
+
+Expected structure:
+- httpGet/tcpSocket/exec: probe type configuration
+- initialDelaySeconds: int
+- periodSeconds: int
+- timeoutSeconds: int
+- failureThreshold: int
+- successThreshold: int
+"""
+
+type KubernetesSecurityContext = dict[str, Any]
+"""
+Kubernetes SecurityContext or PodSecurityContext.
+
+Expected structure:
+- runAsUser: int
+- runAsGroup: int
+- runAsNonRoot: bool
+- fsGroup: int
+- capabilities: dict with add/drop lists
+- seccompProfile: dict
+- seLinuxOptions: dict
+"""
+
+type KubernetesMetadata = dict[str, Any]
+"""
+Kubernetes ObjectMeta structure.
+
+Expected structure:
+- name: str
+- namespace: str
+- labels: dict[str, str]
+- annotations: dict[str, str]
+- uid: str
+- resourceVersion: str
+- generation: int
+- creationTimestamp: str
+"""
+
+# =============================================================================
+# Authentication Flow Types
+# =============================================================================
+
+type AuthenticationExecution = dict[str, str | int | bool]
+"""
+Single authentication execution step in a flow.
+
+Expected structure:
+- authenticator: str (e.g., "auth-cookie", "auth-spnego")
+- requirement: str (REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL)
+- priority: int
+- authenticatorFlow: bool
+- flowAlias: str (if authenticatorFlow is True)
+"""
+
+type AuthenticationExecutionList = list[AuthenticationExecution]
+"""List of authentication execution steps in order of priority."""
+
+# =============================================================================
+# Operational Types
+# =============================================================================
+
+type OperationalStats = dict[str, Any]
+"""
+Runtime operational statistics and metrics.
+
+This is truly dynamic as it contains runtime-collected data
+that may vary based on what metrics are available.
+"""


### PR DESCRIPTION
## Summary

Fixes a bug where ingress creation failed because the code used wrong attribute names, and improves type safety to prevent similar issues in the future.

## Bug Fixes

### Primary Bug: `hostname` vs `host`
The `create_keycloak_ingress()` function in `kubernetes.py` was using `spec.ingress.hostname` but the Pydantic model `KeycloakIngressConfig` defines the field as `host`.

**Impact**: Ingress was created without host rules because `spec.ingress.hostname` always returned `None`.

### Secondary Bug: TLS Config Access
The TLS configuration was accessed incorrectly:
- `getattr(spec.ingress, "tls", {}).get("enabled", False)` → should be `spec.ingress.tls_enabled`
- `getattr(spec.ingress.tls, "secret_name", ...)` → should be `spec.ingress.tls_secret_name`

## Type Safety Improvements

### Root Cause Analysis
The bugs weren't caught because:
1. Function parameters used `spec: Any` instead of `spec: KeycloakSpec`
2. Type checker couldn't validate attribute access on `Any` types

### Prevention Measures

**1. Proper Type Annotations**
Changed 4 functions from `spec: Any` to `spec: KeycloakSpec`:
- `create_keycloak_deployment()`
- `create_keycloak_service()`
- `create_keycloak_ingress()`
- `backup_keycloak_data()`

**2. Semantic Type Aliases**
Created `models/types.py` with type aliases that communicate structure:

| Type Alias | Actual Type | Purpose |
|------------|-------------|---------|
| `KeycloakConfigMap` | `dict[str, str]` | Flat string-to-string Keycloak API configs |
| `KubernetesProbeConfig` | `dict[str, Any]` | K8s probe structures |
| `KubernetesSecurityContext` | `dict[str, Any]` | K8s security context |
| `KubernetesMetadata` | `dict[str, Any]` | K8s ObjectMeta |
| `AuthenticationExecution` | `dict[str, str \| int \| bool]` | Single auth flow step |
| `AuthenticationExecutionList` | `list[AuthenticationExecution]` | List of auth steps |
| `OperationalStats` | `dict[str, Any]` | Runtime metrics |

Key insight: `KeycloakConfigMap = dict[str, str]` is more accurate than `dict[str, Any]` because Keycloak's REST API always uses string values for config blocks (even booleans are `"true"`/`"false"`).

## Testing

- ✅ 387 unit tests pass
- ✅ All quality checks pass (ruff, ty)
- ✅ CRD-Pydantic schema validation passes