### PR TITLE
feat(chart-operator+chart-realm+operator): add password policy and improve events config

### DIFF
--- a/charts/keycloak-operator/crds/keycloakrealm-crd.yaml
+++ b/charts/keycloak-operator/crds/keycloakrealm-crd.yaml
@@ -548,6 +548,55 @@ spec:
                 description: Additional realm attributes
                 additionalProperties:
                   type: string
+              passwordPolicy:
+                type: object
+                description: Password policy configuration
+                properties:
+                  length:
+                    type: integer
+                    minimum: 1
+                    description: Minimum password length
+                  upperCase:
+                    type: integer
+                    minimum: 0
+                    description: Minimum uppercase characters
+                  lowerCase:
+                    type: integer
+                    minimum: 0
+                    description: Minimum lowercase characters
+                  digits:
+                    type: integer
+                    minimum: 0
+                    description: Minimum digit characters
+                  specialChars:
+                    type: integer
+                    minimum: 0
+                    description: Minimum special characters
+                  notUsername:
+                    type: boolean
+                    description: Password cannot equal username
+                  notEmail:
+                    type: boolean
+                    description: Password cannot equal email
+                  hashIterations:
+                    type: integer
+                    minimum: 1
+                    description: PBKDF2 hash iterations
+                  passwordHistory:
+                    type: integer
+                    minimum: 0
+                    description: Number of previous passwords to check
+                  forceExpiredPasswordChange:
+                    type: integer
+                    minimum: 0
+                    description: Days until password expires and must be changed
+                  maxLength:
+                    type: integer
+                    minimum: 1
+                    description: Maximum password length
+                  regexPattern:
+                    type: string
+                    description: Custom regex pattern for password validation
               eventsConfig:
                 type: object
                 description: Event logging configuration

--- a/charts/keycloak-realm/templates/realm.yaml
+++ b/charts/keycloak-realm/templates/realm.yaml
@@ -111,6 +111,13 @@ spec:
       {{- toYaml .Values.roles.realmRoles | nindent 6 }}
   {{- end }}
 
+  {{- with .Values.passwordPolicy }}
+  {{- if or .length .upperCase .lowerCase .digits .specialChars .notUsername .notEmail .hashIterations .passwordHistory .forceExpiredPasswordChange .maxLength .regexPattern }}
+  passwordPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+
   {{- if or .Values.eventsConfig.eventsEnabled .Values.eventsConfig.adminEventsEnabled }}
   eventsConfig:
     {{- toYaml .Values.eventsConfig | nindent 4 }}

--- a/charts/keycloak-realm/values.schema.json
+++ b/charts/keycloak-realm/values.schema.json
@@ -246,6 +246,69 @@
         }
       }
     },
+    "passwordPolicy": {
+      "type": "object",
+      "description": "Password policy configuration",
+      "properties": {
+        "length": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum password length"
+        },
+        "upperCase": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum uppercase characters"
+        },
+        "lowerCase": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum lowercase characters"
+        },
+        "digits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum digit characters"
+        },
+        "specialChars": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Minimum special characters"
+        },
+        "notUsername": {
+          "type": "boolean",
+          "description": "Password cannot equal username"
+        },
+        "notEmail": {
+          "type": "boolean",
+          "description": "Password cannot equal email"
+        },
+        "hashIterations": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "PBKDF2 hash iterations"
+        },
+        "passwordHistory": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of previous passwords to check"
+        },
+        "forceExpiredPasswordChange": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Days until password expires and must be changed (0 = immediate expiration)"
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum password length"
+        },
+        "regexPattern": {
+          "type": "string",
+          "description": "Custom regex pattern for password validation"
+        }
+      }
+    },
     "extraManifests": {
       "type": "array",
       "description": "Extra Kubernetes manifests to deploy (e.g., ExternalSecrets, SealedSecrets, ConfigMaps)",

--- a/charts/keycloak-realm/values.yaml
+++ b/charts/keycloak-realm/values.yaml
@@ -118,6 +118,38 @@ smtpServer:
 # Free-form key-value pairs for custom realm attributes
 attributes: {}
 
+# Password policy configuration (optional)
+# Enforces password requirements for users in this realm
+# Uncomment fields to enable specific policies
+passwordPolicy: {}
+  # Minimum password length (recommended: 12+)
+  # length: 12
+
+  # Character requirements
+  # upperCase: 1
+  # lowerCase: 1
+  # digits: 1
+  # specialChars: 1
+
+  # Content restrictions
+  # notUsername: true
+  # notEmail: true
+
+  # Hash iterations (OWASP recommends 210000 for PBKDF2-SHA256)
+  # hashIterations: 210000
+
+  # Password history (prevent reuse of N previous passwords)
+  # passwordHistory: 5
+
+  # Password expiration in days
+  # forceExpiredPasswordChange: 90
+
+  # Maximum password length
+  # maxLength: 128
+
+  # Custom regex pattern
+  # regexPattern: ""
+
 # Identity Providers (optional)
 # Configure external identity providers (OIDC, SAML, social logins)
 # See CRD documentation for full schema

--- a/src/keycloak_operator/services/realm_reconciler.py
+++ b/src/keycloak_operator/services/realm_reconciler.py
@@ -1811,6 +1811,8 @@ class KeycloakRealmReconciler(BaseReconciler):
                 ("spec", "clientAuthenticationFlow"),
                 ("spec", "dockerAuthenticationFlow"),
                 ("spec", "firstBrokerLoginFlow"),
+                ("spec", "eventsConfig"),
+                ("spec", "passwordPolicy"),
             ]:
                 field_name = field_path[1] if len(field_path) > 1 else "unknown"
                 self.logger.info(f"Updating realm field: {field_name}")

--- a/tests/unit/models/test_realm_events_config.py
+++ b/tests/unit/models/test_realm_events_config.py
@@ -1,0 +1,181 @@
+"""Unit tests for KeycloakEventsConfig model."""
+
+import pytest
+
+from keycloak_operator.models.realm import KeycloakEventsConfig, KeycloakRealmSpec
+
+
+class TestEventsConfigModel:
+    """Tests for KeycloakEventsConfig Pydantic model."""
+
+    def test_defaults(self):
+        """Default values are correct."""
+        config = KeycloakEventsConfig()
+        assert config.events_enabled is False
+        assert config.admin_events_enabled is False
+        assert config.admin_events_details_enabled is False
+        assert config.events_listeners == []
+        assert config.enabled_event_types == []
+        assert config.events_expiration is None
+
+    def test_all_fields_set(self):
+        """All fields can be set."""
+        config = KeycloakEventsConfig(
+            events_enabled=True,
+            events_listeners=["jboss-logging", "email"],
+            enabled_event_types=["LOGIN", "LOGOUT", "REGISTER"],
+            events_expiration=86400,
+            admin_events_enabled=True,
+            admin_events_details_enabled=True,
+        )
+        assert config.events_enabled is True
+        assert config.admin_events_enabled is True
+        assert config.admin_events_details_enabled is True
+        assert len(config.events_listeners) == 2
+        assert "jboss-logging" in config.events_listeners
+        assert "email" in config.events_listeners
+        assert len(config.enabled_event_types) == 3
+        assert config.events_expiration == 86400
+
+    def test_events_expiration_minimum_validation(self):
+        """events_expiration must be at least 1."""
+        with pytest.raises(ValueError):
+            KeycloakEventsConfig(events_expiration=0)
+
+    def test_events_expiration_negative_validation(self):
+        """events_expiration cannot be negative."""
+        with pytest.raises(ValueError):
+            KeycloakEventsConfig(events_expiration=-1)
+
+    def test_alias_mapping_camel_case(self):
+        """Aliases work for camelCase input."""
+        config = KeycloakEventsConfig.model_validate(
+            {
+                "eventsEnabled": True,
+                "adminEventsEnabled": True,
+                "adminEventsDetailsEnabled": True,
+                "eventsListeners": ["jboss-logging"],
+                "enabledEventTypes": ["LOGIN"],
+                "eventsExpiration": 3600,
+            }
+        )
+        assert config.events_enabled is True
+        assert config.admin_events_enabled is True
+        assert config.admin_events_details_enabled is True
+        assert config.events_listeners == ["jboss-logging"]
+        assert config.enabled_event_types == ["LOGIN"]
+        assert config.events_expiration == 3600
+
+    def test_partial_configuration(self):
+        """Partial configuration works correctly."""
+        config = KeycloakEventsConfig(
+            events_enabled=True,
+            events_listeners=["jboss-logging"],
+        )
+        assert config.events_enabled is True
+        assert config.admin_events_enabled is False
+        assert config.events_listeners == ["jboss-logging"]
+        assert config.enabled_event_types == []
+
+    def test_empty_listeners_list(self):
+        """Empty listeners list is valid."""
+        config = KeycloakEventsConfig(events_enabled=True, events_listeners=[])
+        assert config.events_listeners == []
+
+    def test_multiple_event_types(self):
+        """Multiple event types can be specified."""
+        event_types = [
+            "LOGIN",
+            "LOGIN_ERROR",
+            "LOGOUT",
+            "REGISTER",
+            "CODE_TO_TOKEN",
+            "REFRESH_TOKEN",
+        ]
+        config = KeycloakEventsConfig(enabled_event_types=event_types)
+        assert config.enabled_event_types == event_types
+        assert len(config.enabled_event_types) == 6
+
+
+class TestRealmSpecWithEventsConfig:
+    """Tests for KeycloakRealmSpec with events configuration."""
+
+    def test_default_events_config(self):
+        """Default events config is created."""
+        spec = KeycloakRealmSpec(
+            realm_name="test-realm",
+            operator_ref={"namespace": "keycloak"},
+        )
+        assert spec.events_config is not None
+        assert spec.events_config.events_enabled is False
+        assert spec.events_config.admin_events_enabled is False
+
+    def test_custom_events_config(self):
+        """Custom events config is applied."""
+        spec = KeycloakRealmSpec(
+            realm_name="test-realm",
+            operator_ref={"namespace": "keycloak"},
+            events_config=KeycloakEventsConfig(
+                events_enabled=True,
+                events_listeners=["jboss-logging"],
+                admin_events_enabled=True,
+            ),
+        )
+        assert spec.events_config.events_enabled is True
+        assert "jboss-logging" in spec.events_config.events_listeners
+        assert spec.events_config.admin_events_enabled is True
+
+    def test_to_keycloak_config_includes_events(self):
+        """to_keycloak_config() includes events configuration."""
+        spec = KeycloakRealmSpec(
+            realm_name="test-realm",
+            operator_ref={"namespace": "keycloak"},
+            events_config=KeycloakEventsConfig(
+                events_enabled=True,
+                events_listeners=["jboss-logging", "email"],
+                enabled_event_types=["LOGIN", "LOGOUT"],
+                events_expiration=604800,
+                admin_events_enabled=True,
+                admin_events_details_enabled=True,
+            ),
+        )
+        config = spec.to_keycloak_config()
+
+        assert config["eventsEnabled"] is True
+        assert config["eventsListeners"] == ["jboss-logging", "email"]
+        assert config["enabledEventTypes"] == ["LOGIN", "LOGOUT"]
+        assert config["eventsExpiration"] == 604800
+        assert config["adminEventsEnabled"] is True
+        assert config["adminEventsDetailsEnabled"] is True
+
+    def test_to_keycloak_config_default_events(self):
+        """to_keycloak_config() includes default events config."""
+        spec = KeycloakRealmSpec(
+            realm_name="test-realm",
+            operator_ref={"namespace": "keycloak"},
+        )
+        config = spec.to_keycloak_config()
+
+        assert config["eventsEnabled"] is False
+        assert config["eventsListeners"] == []
+        assert config["enabledEventTypes"] == []
+        assert config["eventsExpiration"] is None
+        assert config["adminEventsEnabled"] is False
+        assert config["adminEventsDetailsEnabled"] is False
+
+    def test_events_config_alias_in_realm_spec(self):
+        """KeycloakRealmSpec accepts eventsConfig alias."""
+        spec = KeycloakRealmSpec.model_validate(
+            {
+                "realmName": "test-realm",
+                "operatorRef": {"namespace": "keycloak"},
+                "eventsConfig": {
+                    "eventsEnabled": True,
+                    "eventsListeners": ["jboss-logging"],
+                    "adminEventsEnabled": True,
+                },
+            }
+        )
+        assert spec.events_config.events_enabled is True
+        assert spec.events_config.events_listeners == ["jboss-logging"]
+        assert spec.events_config.admin_events_enabled is True

--- a/tests/unit/models/test_realm_password_policy.py
+++ b/tests/unit/models/test_realm_password_policy.py
@@ -1,0 +1,259 @@
+"""Unit tests for KeycloakPasswordPolicy model."""
+
+import pytest
+
+from keycloak_operator.models.realm import (
+    KeycloakPasswordPolicy,
+    KeycloakRealmSpec,
+)
+
+
+class TestPasswordPolicyModel:
+    """Tests for KeycloakPasswordPolicy Pydantic model."""
+
+    def test_empty_policy_string(self):
+        """Empty policy generates empty string."""
+        policy = KeycloakPasswordPolicy()
+        assert policy.to_policy_string() == ""
+
+    def test_single_policy_length(self):
+        """Single length policy generates correct string."""
+        policy = KeycloakPasswordPolicy(length=8)
+        assert policy.to_policy_string() == "length(8)"
+
+    def test_single_policy_uppercase(self):
+        """Single upperCase policy generates correct string."""
+        policy = KeycloakPasswordPolicy(upper_case=2)
+        assert policy.to_policy_string() == "upperCase(2)"
+
+    def test_multiple_policies_and_separated(self):
+        """Multiple policies are separated with ' and '."""
+        policy = KeycloakPasswordPolicy(
+            length=12,
+            upper_case=1,
+            lower_case=1,
+            digits=1,
+        )
+        result = policy.to_policy_string()
+        assert "length(12)" in result
+        assert "upperCase(1)" in result
+        assert "lowerCase(1)" in result
+        assert "digits(1)" in result
+        # Verify "and" separation
+        assert " and " in result
+        parts = result.split(" and ")
+        assert len(parts) == 4
+
+    def test_boolean_policy_not_username(self):
+        """notUsername boolean policy generates correct string."""
+        policy = KeycloakPasswordPolicy(not_username=True)
+        assert policy.to_policy_string() == "notUsername"
+
+    def test_boolean_policy_not_email(self):
+        """notEmail boolean policy generates correct string."""
+        policy = KeycloakPasswordPolicy(not_email=True)
+        assert policy.to_policy_string() == "notEmail"
+
+    def test_boolean_policies_false_excluded(self):
+        """False boolean policies are excluded."""
+        policy = KeycloakPasswordPolicy(not_username=False, not_email=False)
+        assert policy.to_policy_string() == ""
+
+    def test_hash_iterations(self):
+        """hashIterations policy generates correct string."""
+        policy = KeycloakPasswordPolicy(hash_iterations=210000)
+        assert policy.to_policy_string() == "hashIterations(210000)"
+
+    def test_password_history(self):
+        """passwordHistory policy generates correct string."""
+        policy = KeycloakPasswordPolicy(password_history=5)
+        assert policy.to_policy_string() == "passwordHistory(5)"
+
+    def test_force_expired_password_change(self):
+        """forceExpiredPasswordChange policy generates correct string."""
+        policy = KeycloakPasswordPolicy(force_expired_password_change=90)
+        assert policy.to_policy_string() == "forceExpiredPasswordChange(90)"
+
+    def test_max_length(self):
+        """maxLength policy generates correct string."""
+        policy = KeycloakPasswordPolicy(max_length=128)
+        assert policy.to_policy_string() == "maxLength(128)"
+
+    def test_regex_pattern(self):
+        """regexPattern policy generates correct string."""
+        policy = KeycloakPasswordPolicy(regex_pattern="^[a-zA-Z0-9]+$")
+        assert policy.to_policy_string() == "regexPattern(^[a-zA-Z0-9]+$)"
+
+    def test_all_policies_combined(self):
+        """All policies combined generate complete string."""
+        policy = KeycloakPasswordPolicy(
+            length=12,
+            upper_case=1,
+            lower_case=1,
+            digits=1,
+            special_chars=1,
+            not_username=True,
+            not_email=True,
+            hash_iterations=210000,
+            password_history=5,
+            force_expired_password_change=90,
+            max_length=128,
+            regex_pattern="^[a-zA-Z0-9]+$",
+        )
+        result = policy.to_policy_string()
+        assert "length(12)" in result
+        assert "upperCase(1)" in result
+        assert "lowerCase(1)" in result
+        assert "digits(1)" in result
+        assert "specialChars(1)" in result
+        assert "notUsername" in result
+        assert "notEmail" in result
+        assert "hashIterations(210000)" in result
+        assert "passwordHistory(5)" in result
+        assert "forceExpiredPasswordChange(90)" in result
+        assert "maxLength(128)" in result
+        assert "regexPattern(^[a-zA-Z0-9]+$)" in result
+
+    def test_validation_length_minimum(self):
+        """Length must be at least 1."""
+        with pytest.raises(ValueError):
+            KeycloakPasswordPolicy(length=0)
+
+    def test_validation_max_length_minimum(self):
+        """maxLength must be at least 1."""
+        with pytest.raises(ValueError):
+            KeycloakPasswordPolicy(max_length=0)
+
+    def test_validation_hash_iterations_minimum(self):
+        """hashIterations must be at least 1."""
+        with pytest.raises(ValueError):
+            KeycloakPasswordPolicy(hash_iterations=0)
+
+    def test_validation_uppercase_allows_zero(self):
+        """upperCase allows 0 (explicitly disable)."""
+        policy = KeycloakPasswordPolicy(upper_case=0)
+        assert "upperCase(0)" in policy.to_policy_string()
+
+    def test_validation_password_history_allows_zero(self):
+        """passwordHistory allows 0 (disable history check)."""
+        policy = KeycloakPasswordPolicy(password_history=0)
+        assert "passwordHistory(0)" in policy.to_policy_string()
+
+    def test_alias_mapping_camel_case(self):
+        """Aliases work for camelCase input."""
+        policy = KeycloakPasswordPolicy.model_validate(
+            {
+                "upperCase": 2,
+                "lowerCase": 2,
+                "specialChars": 1,
+                "notUsername": True,
+                "notEmail": True,
+                "hashIterations": 100000,
+                "passwordHistory": 3,
+                "forceExpiredPasswordChange": 30,
+                "maxLength": 64,
+                "regexPattern": ".*",
+            }
+        )
+        assert policy.upper_case == 2
+        assert policy.lower_case == 2
+        assert policy.special_chars == 1
+        assert policy.not_username is True
+        assert policy.not_email is True
+        assert policy.hash_iterations == 100000
+        assert policy.password_history == 3
+        assert policy.force_expired_password_change == 30
+        assert policy.max_length == 64
+        assert policy.regex_pattern == ".*"
+
+    def test_policy_order_is_consistent(self):
+        """Policy string order is consistent for same input."""
+        policy = KeycloakPasswordPolicy(
+            length=8,
+            upper_case=1,
+            digits=1,
+            not_username=True,
+        )
+        result1 = policy.to_policy_string()
+        result2 = policy.to_policy_string()
+        assert result1 == result2
+
+
+class TestRealmSpecWithPasswordPolicy:
+    """Tests for KeycloakRealmSpec with password policy."""
+
+    def test_to_keycloak_config_includes_policy(self):
+        """to_keycloak_config() includes passwordPolicy."""
+        spec = KeycloakRealmSpec(
+            realm_name="test-realm",
+            operator_ref={"namespace": "keycloak"},
+            password_policy=KeycloakPasswordPolicy(length=12, upper_case=1),
+        )
+        config = spec.to_keycloak_config()
+        assert "passwordPolicy" in config
+        assert "length(12)" in config["passwordPolicy"]
+        assert "upperCase(1)" in config["passwordPolicy"]
+
+    def test_to_keycloak_config_omits_empty_policy(self):
+        """to_keycloak_config() omits passwordPolicy when empty."""
+        spec = KeycloakRealmSpec(
+            realm_name="test-realm",
+            operator_ref={"namespace": "keycloak"},
+            password_policy=KeycloakPasswordPolicy(),
+        )
+        config = spec.to_keycloak_config()
+        assert "passwordPolicy" not in config
+
+    def test_to_keycloak_config_no_policy_field(self):
+        """to_keycloak_config() omits passwordPolicy when not set."""
+        spec = KeycloakRealmSpec(
+            realm_name="test-realm",
+            operator_ref={"namespace": "keycloak"},
+        )
+        config = spec.to_keycloak_config()
+        assert "passwordPolicy" not in config
+
+    def test_realm_spec_password_policy_alias(self):
+        """KeycloakRealmSpec accepts passwordPolicy alias."""
+        spec = KeycloakRealmSpec.model_validate(
+            {
+                "realmName": "test-realm",
+                "operatorRef": {"namespace": "keycloak"},
+                "passwordPolicy": {
+                    "length": 10,
+                    "notUsername": True,
+                },
+            }
+        )
+        assert spec.password_policy is not None
+        assert spec.password_policy.length == 10
+        assert spec.password_policy.not_username is True
+
+    def test_comprehensive_policy_in_realm_config(self):
+        """Comprehensive password policy is correctly included in realm config."""
+        spec = KeycloakRealmSpec(
+            realm_name="secure-realm",
+            operator_ref={"namespace": "keycloak"},
+            password_policy=KeycloakPasswordPolicy(
+                length=12,
+                upper_case=1,
+                lower_case=1,
+                digits=1,
+                special_chars=1,
+                not_username=True,
+                hash_iterations=210000,
+                password_history=5,
+            ),
+        )
+        config = spec.to_keycloak_config()
+        policy = config["passwordPolicy"]
+
+        # Verify all components are present
+        assert "length(12)" in policy
+        assert "upperCase(1)" in policy
+        assert "lowerCase(1)" in policy
+        assert "digits(1)" in policy
+        assert "specialChars(1)" in policy
+        assert "notUsername" in policy
+        assert "hashIterations(210000)" in policy
+        assert "passwordHistory(5)" in policy


### PR DESCRIPTION
## Summary

This PR implements **password policies** for Keycloak realms (#311) and improves the events configuration support.

## Changes

### Password Policies

Adds a structured `passwordPolicy` field to the `KeycloakRealmSpec` that allows configuring password requirements:

```yaml
apiVersion: vriesdemichael.github.io/v1
kind: KeycloakRealm
spec:
  realmName: my-realm
  operatorRef:
    namespace: keycloak-system
    
  passwordPolicy:
    length: 12
    upperCase: 1
    lowerCase: 1
    digits: 1
    specialChars: 1
    notUsername: true
    hashIterations: 210000  # OWASP recommendation
    passwordHistory: 5
```

**Supported policies:**
- `length` - Minimum password length
- `upperCase` / `lowerCase` - Character requirements
- `digits` / `specialChars` - Numeric and special character requirements
- `notUsername` / `notEmail` - Content restrictions
- `hashIterations` - PBKDF2 hash iterations (OWASP recommends 210000)
- `passwordHistory` - Prevent password reuse
- `forceExpiredPasswordChange` - Password expiration in days
- `maxLength` - Maximum password length
- `regexPattern` - Custom regex validation

The model converts the structured config to Keycloak's `"length(12) and upperCase(1) and ..."` format.

### Events Config Improvements

- Added `model_config` with `populate_by_name: True` for camelCase alias support
- Added proper aliases to all fields (`eventsEnabled`, `adminEventsEnabled`, etc.)
- Added dedicated update handler in reconciler for `eventsConfig` changes

## Files Changed

| File | Changes |
|------|---------|
| `src/keycloak_operator/models/realm.py` | Added `KeycloakPasswordPolicy` model, updated `KeycloakEventsConfig` |
| `src/keycloak_operator/services/realm_reconciler.py` | Added update handlers for new fields |
| `charts/keycloak-operator/crds/keycloakrealm-crd.yaml` | Added `passwordPolicy` to CRD schema |
| `charts/keycloak-realm/values.yaml` | Added `passwordPolicy` section with examples |
| `charts/keycloak-realm/values.schema.json` | Added JSON schema for `passwordPolicy` |
| `charts/keycloak-realm/templates/realm.yaml` | Added conditional rendering for `passwordPolicy` |
| `tests/unit/models/test_realm_password_policy.py` | 25 unit tests for password policy model |
| `tests/unit/models/test_realm_events_config.py` | 13 unit tests for events config model |
| `tests/integration/test_helm_charts.py` | Integration test for Helm realm with password policy |

## Testing

- ✅ All 587 unit tests pass
- ✅ All 76 integration tests pass
- ✅ Password policy verified working against Keycloak 26.4.0

## Issues

Closes #311

## Checklist

- [x] Code follows project conventions
- [x] Tests added for new functionality
- [x] CRD schema updated
- [x] Helm chart values and schema updated
- [x] All tests pass (`make test`)
- [x] Conventional commit message with proper scope