### PR TITLE
fix(chart-realm): update drift detection documentation reference

### DIFF
--- a/charts/keycloak-realm/values.yaml
+++ b/charts/keycloak-realm/values.yaml
@@ -346,7 +346,7 @@ userFederation: []
 
 # Event logging configuration (optional)
 # Note: Admin events are enabled by default because they are required for
-# drift detection to work properly. Disabling them is not recommended.
+# drift detection to work properly. See docs/guides/drift-detection.md for details.
 eventsConfig:
   eventsEnabled: false
   eventsListeners: []


### PR DESCRIPTION
## Summary

- Updates the comment in `values.yaml` to reference the drift detection guide instead of just saying "not recommended"
- **Triggers release-please** to create a release for the realm chart (0.3.9) which will include the previous drift detection default changes from commit 282b2bc

## Context

The previous PR that merged drift detection changes modified `charts/keycloak-realm/values.yaml` and `values.schema.json` (enabling admin events by default for drift detection), but used `refactor(operator)` scope instead of including `chart-realm`. This PR adds a minor documentation improvement with the correct scope to trigger the realm chart release.

## Changes included in realm chart 0.3.9
- Default `adminEventsEnabled: true` (required for drift detection)
- Default `adminEventsDetailsEnabled: true` (recommended for drift detection)
- Updated schema with better descriptions
- Documentation reference improvement (this PR)