### PR TITLE
ci: prevent auto-merge when jobs are cancelled

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -173,13 +173,18 @@ jobs:
           echo "- Integration Tests: ${{ needs.integration-tests.result }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Check if any required job failed
+          # Check if any required job failed or was cancelled
           if [[ "${{ needs.unit-tests.result }}" == "failure" ]] || \
              [[ "${{ needs.code-quality.result }}" == "failure" ]] || \
              [[ "${{ needs.docs-validation.result }}" == "failure" ]] || \
              [[ "${{ needs.security-scans.result }}" == "failure" ]] || \
-             [[ "${{ needs.integration-tests.result }}" == "failure" ]]; then
-            echo "❌ Required checks failed" >> $GITHUB_STEP_SUMMARY
+             [[ "${{ needs.integration-tests.result }}" == "failure" ]] || \
+             [[ "${{ needs.unit-tests.result }}" == "cancelled" ]] || \
+             [[ "${{ needs.code-quality.result }}" == "cancelled" ]] || \
+             [[ "${{ needs.docs-validation.result }}" == "cancelled" ]] || \
+             [[ "${{ needs.security-scans.result }}" == "cancelled" ]] || \
+             [[ "${{ needs.integration-tests.result }}" == "cancelled" ]]; then
+            echo "❌ Required checks failed or were cancelled" >> $GITHUB_STEP_SUMMARY
             echo "passed=false" >> $GITHUB_OUTPUT
             exit 1
           fi


### PR DESCRIPTION
## Summary

Fixes a bug where PRs could be auto-merged even when integration tests were cancelled mid-run.

## Problem

The `all-required-checks-passed` job only checked for `failure` and `skipped` states:
- ❌ `failure` → fail the check
- ❌ `skipped` → fail the check  
- ⚠️ `cancelled` → **was not checked** → treated as success!

This allowed the kopf 1.42.3 upgrade PR (#446) to be auto-merged while integration tests were still running. When the merge happened, the tests were cancelled, but the check had already passed.

## Fix

Add explicit checks for `cancelled` state on all required jobs.

## Note

This is a defense-in-depth fix. The root cause is that branch protection with required status checks is not enabled on the `main` branch. Consider enabling branch protection to prevent this class of issues.