### PR TITLE
ci: improve documentation snippet validation coverage

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -392,7 +392,7 @@ When tracing is enabled, the operator creates spans for:
 
 Each span includes semantic attributes:
 
-```
+```text
 k8s.namespace: default
 k8s.resource.name: my-keycloak
 k8s.resource.type: keycloak
@@ -412,6 +412,10 @@ When `propagateToKeycloak: true`, the operator configures managed Keycloak insta
 The Keycloak CR will automatically include:
 
 ```yaml
+apiVersion: vriesdemichael.github.io/v1
+kind: Keycloak
+metadata:
+  name: example
 spec:
   tracing:
     enabled: true
@@ -451,7 +455,7 @@ The operator uses W3C Trace Context (`traceparent` header) for trace propagation
 
 Example trace context header:
 
-```
+```text
 traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 ```
 

--- a/docs/operations/secret-rotation.md
+++ b/docs/operations/secret-rotation.md
@@ -46,6 +46,7 @@ Since rotation is atomic, your applications must pick up the new secret immediat
 2. Annotate your **Application Deployment** (not the Secret):
 
 ```yaml
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-app

--- a/scripts/lib/doc_extractor.py
+++ b/scripts/lib/doc_extractor.py
@@ -349,6 +349,14 @@ def detect_yaml_context(
     if parsed.keys() & cnpg_keys and "spec" not in parsed:
         return ReferenceContext.K8S_OTHER, ""
 
+    # Check for partial config snippets that should be categorized (not UNKNOWN)
+    partial_config_keys = {
+        "config",  # Identity provider config fragments
+        "mappers",  # User federation mappers
+    }
+    if parsed.keys() & partial_config_keys and len(parsed) == 1:
+        return ReferenceContext.K8S_OTHER, ""
+
     # Check if top-level keys match Helm values structure
     top_keys = set(parsed.keys())
 

--- a/scripts/schemas/external/kyverno-clusterpolicy.schema.json
+++ b/scripts/schemas/external/kyverno-clusterpolicy.schema.json
@@ -1,0 +1,9466 @@
+{
+  "description": "ClusterPolicy declares validation, mutation, and generation behaviors for matching resources.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec declares policy behaviors.",
+      "properties": {
+        "admission": {
+          "default": true,
+          "description": "Admission controls if rules are applied during admission.\nOptional. Default value is \"true\".",
+          "type": "boolean"
+        },
+        "applyRules": {
+          "description": "ApplyRules controls how rules in a policy are applied. Rule are processed in\nthe order of declaration. When set to `One` processing stops after a rule has\nbeen applied i.e. the rule matches and results in a pass, fail, or error. When\nset to `All` all rules in the policy are processed. The default is `All`.",
+          "enum": [
+            "All",
+            "One"
+          ],
+          "type": "string"
+        },
+        "background": {
+          "default": true,
+          "description": "Background controls if rules are applied to existing resources during a background scan.\nOptional. Default value is \"true\". The value must be set to \"false\" if the policy rule\nuses variables that are only available in the admission review request (e.g. user name).",
+          "type": "boolean"
+        },
+        "emitWarning": {
+          "default": false,
+          "description": "EmitWarning enables API response warnings for mutate policy rules or validate policy rules with validationFailureAction set to Audit.\nEnabling this option will extend admission request processing times. The default value is \"false\".",
+          "type": "boolean"
+        },
+        "failurePolicy": {
+          "description": "Deprecated, use failurePolicy under the webhookConfiguration instead.",
+          "enum": [
+            "Ignore",
+            "Fail"
+          ],
+          "type": "string"
+        },
+        "generateExisting": {
+          "description": "Deprecated, use generateExisting under the generate rule instead",
+          "type": "boolean"
+        },
+        "generateExistingOnPolicyUpdate": {
+          "description": "Deprecated, use generateExisting instead",
+          "type": "boolean"
+        },
+        "mutateExistingOnPolicyUpdate": {
+          "description": "Deprecated, use mutateExistingOnPolicyUpdate under the mutate rule instead",
+          "type": "boolean"
+        },
+        "rules": {
+          "description": "Rules is a list of Rule instances. A Policy contains multiple rules and\neach rule can validate, mutate, or generate resources.",
+          "items": {
+            "description": "Rule defines a validation, mutation, or generation control for matching resources.\nEach rules contains a match declaration to select resources, and an optional exclude\ndeclaration to specify which resources to exclude.",
+            "properties": {
+              "celPreconditions": {
+                "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a\nset of CEL conditions. It can only be used with the validate.cel subrule",
+                "items": {
+                  "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                  "properties": {
+                    "expression": {
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "context": {
+                "description": "Context defines variables and data sources that can be used during rule execution.",
+                "items": {
+                  "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                  "oneOf": [
+                    {
+                      "required": [
+                        "configMap"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "apiCall"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "imageRegistry"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "variable"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "globalReference"
+                      ]
+                    }
+                  ],
+                  "properties": {
+                    "apiCall": {
+                      "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                      "properties": {
+                        "data": {
+                          "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                          "items": {
+                            "description": "RequestData contains the HTTP POST data",
+                            "properties": {
+                              "key": {
+                                "description": "Key is a unique identifier for the data value",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the data value",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "default": {
+                          "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "jmesPath": {
+                          "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                          "type": "string"
+                        },
+                        "method": {
+                          "default": "GET",
+                          "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                          "enum": [
+                            "GET",
+                            "POST"
+                          ],
+                          "type": "string"
+                        },
+                        "service": {
+                          "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                          "properties": {
+                            "caBundle": {
+                              "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                              "type": "string"
+                            },
+                            "headers": {
+                              "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                              "items": {
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the header key",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the header value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "url": {
+                              "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object"
+                        },
+                        "urlPath": {
+                          "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "configMap": {
+                      "description": "ConfigMap is the ConfigMap reference.",
+                      "properties": {
+                        "name": {
+                          "description": "Name is the ConfigMap name.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the ConfigMap namespace.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "globalReference": {
+                      "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                      "properties": {
+                        "jmesPath": {
+                          "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the global context entry",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "imageRegistry": {
+                      "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                      "properties": {
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "jmesPath": {
+                          "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                          "type": "string"
+                        },
+                        "reference": {
+                          "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "reference"
+                      ],
+                      "type": "object"
+                    },
+                    "name": {
+                      "description": "Name is the variable name.",
+                      "type": "string"
+                    },
+                    "variable": {
+                      "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                      "properties": {
+                        "default": {
+                          "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "jmesPath": {
+                          "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "exclude": {
+                "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
+                "properties": {
+                  "all": {
+                    "description": "All allows specifying resources which will be ANDed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "any": {
+                    "description": "Any allows specifying resources which will be ORed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "generate": {
+                "description": "Generation is used to create new resources.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "APIVersion specifies resource apiVersion.",
+                    "type": "string"
+                  },
+                  "clone": {
+                    "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                    "properties": {
+                      "name": {
+                        "description": "Name specifies name of the resource.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace specifies source resource namespace.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "cloneList": {
+                    "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                    "properties": {
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespace": {
+                        "description": "Namespace specifies source resource namespace.",
+                        "type": "string"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "data": {
+                    "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "foreach": {
+                    "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "items": {
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion specifies resource apiVersion.",
+                          "type": "string"
+                        },
+                        "clone": {
+                          "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "properties": {
+                            "name": {
+                              "description": "Name specifies name of the resource.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "cloneList": {
+                          "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                          "properties": {
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies source resource namespace.",
+                              "type": "string"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                        "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "globalReference": {
+                                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                "properties": {
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the global context entry",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object"
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "data": {
+                          "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "kind": {
+                          "description": "Kind specifies resource kind.",
+                          "type": "string"
+                        },
+                        "list": {
+                          "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name specifies the resource name.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "properties": {
+                            "all": {
+                              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "any": {
+                              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "generateExisting": {
+                    "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind specifies resource kind.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name specifies the resource name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace specifies resource namespace.",
+                    "type": "string"
+                  },
+                  "orphanDownstreamOnPolicyDelete": {
+                    "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "synchronize": {
+                    "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                    "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "imageExtractors": {
+                "additionalProperties": {
+                  "items": {
+                    "properties": {
+                      "jmesPath": {
+                        "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                "type": "object"
+              },
+              "match": {
+                "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                "not": {
+                  "required": [
+                    "any",
+                    "all"
+                  ]
+                },
+                "properties": {
+                  "all": {
+                    "description": "All allows specifying resources which will be ANDed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "any": {
+                    "description": "Any allows specifying resources which will be ORed",
+                    "items": {
+                      "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                      "properties": {
+                        "clusterRoles": {
+                          "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "description": "ResourceDescription contains information about the resource being created or modified.",
+                          "not": {
+                            "required": [
+                              "name",
+                              "names"
+                            ]
+                          },
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                              "type": "object"
+                            },
+                            "kinds": {
+                              "description": "Kinds is a list of resource kinds.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                              "type": "string"
+                            },
+                            "names": {
+                              "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "namespaceSelector": {
+                              "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "namespaces": {
+                              "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "selector": {
+                              "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "roles": {
+                          "description": "Roles is the list of namespaced role names for the user.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subjects": {
+                          "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                          "items": {
+                            "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the object being referenced.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                    "not": {
+                      "required": [
+                        "name",
+                        "names"
+                      ]
+                    },
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "mutate": {
+                "description": "Mutation is used to modify matching resources.",
+                "properties": {
+                  "foreach": {
+                    "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "items": {
+                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "properties": {
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                        "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "globalReference": {
+                                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                "properties": {
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the global context entry",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object"
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "foreach": {
+                          "description": "Foreach declares a nested foreach iterator",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "list": {
+                          "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                          "type": "string"
+                        },
+                        "order": {
+                          "description": "Order defines the iteration order on the list.\nCan be Ascending to iterate from first to last element or Descending to iterate in from last to first element.",
+                          "enum": [
+                            "Ascending",
+                            "Descending"
+                          ],
+                          "type": "string"
+                        },
+                        "patchStrategicMerge": {
+                          "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "patchesJson6902": {
+                          "description": "PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources.\nSee https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "properties": {
+                            "all": {
+                              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "any": {
+                              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "mutateExistingOnPolicyUpdate": {
+                    "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                    "type": "boolean"
+                  },
+                  "patchStrategicMerge": {
+                    "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "patchesJson6902": {
+                    "description": "PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources.\nSee https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/.",
+                    "type": "string"
+                  },
+                  "targets": {
+                    "description": "Targets defines the target resources to be mutated.",
+                    "items": {
+                      "description": "TargetResourceSpec defines targets for mutating existing resources.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion specifies resource apiVersion.",
+                          "type": "string"
+                        },
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                        "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "globalReference": {
+                                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                "properties": {
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the global context entry",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object"
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "kind": {
+                          "description": "Kind specifies resource kind.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name specifies the resource name.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "selector": {
+                          "description": "Selector allows you to select target resources with their labels.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Name is a label to identify the rule, It must be unique within the policy.",
+                "maxLength": 63,
+                "type": "string"
+              },
+              "preconditions": {
+                "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "reportProperties": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "ReportProperties are the additional properties from the rule that will be added to the policy report result",
+                "type": "object"
+              },
+              "skipBackgroundRequests": {
+                "default": true,
+                "description": "SkipBackgroundRequests bypasses admission requests that are sent by the background controller.\nThe default value is set to \"true\", it must be set to \"false\" to apply\ngenerate and mutateExisting rules to those requests.",
+                "type": "boolean"
+              },
+              "validate": {
+                "description": "Validation is used to validate matching resources.",
+                "properties": {
+                  "allowExistingViolations": {
+                    "default": true,
+                    "description": "AllowExistingViolations allows prexisting violating resources to continue violating a policy.",
+                    "type": "boolean"
+                  },
+                  "anyPattern": {
+                    "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "assert": {
+                    "description": "Assert defines a kyverno-json assertion tree.",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "cel": {
+                    "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                    "properties": {
+                      "auditAnnotations": {
+                        "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                        "items": {
+                          "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                          "properties": {
+                            "key": {
+                              "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
+                              "type": "string"
+                            },
+                            "valueExpression": {
+                              "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "valueExpression"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "expressions": {
+                        "description": "Expressions is a list of CELExpression types.",
+                        "items": {
+                          "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains\nline breaks. The message must not contain line breaks.\nIf unset, the message is \"failed rule: {Rule}\".\ne.g. \"must be a URL with the host matching spec.host\"\nIf the Expression contains line breaks. Message is required.\nThe message must not contain line breaks.\nIf unset, the message is \"failed Expression: {Expression}\".",
+                              "type": "string"
+                            },
+                            "messageExpression": {
+                              "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.\nSince messageExpression is used as a failure message, it must evaluate to a string.\nIf both message and messageExpression are present on a validation, then messageExpression will be used if validation fails.\nIf messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced\nas if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string\nthat contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and\nthe fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged.\nmessageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'.\nExample:\n\"object.x must be less than max (\"+string(params.max)+\")\"",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason represents a machine-readable description of why this validation failed.\nIf this is the first validation in the list to fail, this reason, as well as the\ncorresponding HTTP response code, are used in the\nHTTP response to the client.\nThe currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\".\nIf not set, StatusReasonInvalid is used in the response to the client.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "generate": {
+                        "default": false,
+                        "description": "Generate specifies whether to generate a Kubernetes ValidatingAdmissionPolicy from the rule.\nOptional. Defaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "paramKind": {
+                        "description": "ParamKind is a tuple of Group Kind and Version.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "APIVersion is the API group version the resources belong to.\nIn format of \"group/version\".\nRequired.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind is the API kind the resources belong to.\nRequired.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "paramRef": {
+                        "description": "ParamRef references a parameter resource.",
+                        "properties": {
+                          "name": {
+                            "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                            "type": "string"
+                          },
+                          "parameterNotFoundAction": {
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "variables": {
+                        "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
+                        "items": {
+                          "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables.\nThe variable can be accessed in other expressions through `variables`\nFor example, if name is \"foo\", the variable will be available as `variables.foo`",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "deny": {
+                    "description": "Deny defines conditions used to pass or fail a validation rule.",
+                    "properties": {
+                      "conditions": {
+                        "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "failureAction": {
+                    "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                    "enum": [
+                      "Audit",
+                      "Enforce"
+                    ],
+                    "type": "string"
+                  },
+                  "failureActionOverrides": {
+                    "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                    "items": {
+                      "properties": {
+                        "action": {
+                          "description": "ValidationFailureAction defines the policy validation failure action",
+                          "enum": [
+                            "audit",
+                            "enforce",
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
+                        },
+                        "namespaceSelector": {
+                          "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "namespaces": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "foreach": {
+                    "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                    "items": {
+                      "description": "ForEachValidation applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "properties": {
+                        "anyPattern": {
+                          "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                            "oneOf": [
+                              {
+                                "required": [
+                                  "configMap"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "apiCall"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "imageRegistry"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "variable"
+                                ]
+                              },
+                              {
+                                "required": [
+                                  "globalReference"
+                                ]
+                              }
+                            ],
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                        "type": "string"
+                                      },
+                                      "headers": {
+                                        "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is the header key",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the header value",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "globalReference": {
+                                "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                "properties": {
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the global context entry",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object"
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "deny": {
+                          "description": "Deny defines conditions used to pass or fail a validation rule.",
+                          "properties": {
+                            "conditions": {
+                              "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "elementScope": {
+                          "description": "ElementScope specifies whether to use the current list element as the scope for validation. Defaults to \"true\" if not specified.\nWhen set to \"false\", \"request.object\" is used as the validation scope within the foreach\nblock to allow referencing other elements in the subtree.",
+                          "type": "boolean"
+                        },
+                        "foreach": {
+                          "description": "Foreach declares a nested foreach iterator",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "list": {
+                          "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "description": "Pattern specifies an overlay-style pattern used to check resources.",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "preconditions": {
+                          "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "properties": {
+                            "all": {
+                              "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "any": {
+                              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                              "items": {
+                                "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                    "enum": [
+                                      "Equals",
+                                      "NotEquals",
+                                      "In",
+                                      "AnyIn",
+                                      "AllIn",
+                                      "NotIn",
+                                      "AnyNotIn",
+                                      "AllNotIn",
+                                      "GreaterThanOrEquals",
+                                      "GreaterThan",
+                                      "LessThanOrEquals",
+                                      "LessThan",
+                                      "DurationGreaterThanOrEquals",
+                                      "DurationGreaterThan",
+                                      "DurationLessThanOrEquals",
+                                      "DurationLessThan"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "manifests": {
+                    "description": "Manifest specifies conditions for manifest verification",
+                    "properties": {
+                      "annotationDomain": {
+                        "description": "AnnotationDomain is custom domain of annotation for message and signature. Default is \"cosign.sigstore.dev\".",
+                        "type": "string"
+                      },
+                      "attestors": {
+                        "description": "Attestors specified the required attestors (i.e. authorities)",
+                        "items": {
+                          "properties": {
+                            "count": {
+                              "description": "Count specifies the required number of entries that must match. If the count is null, all entries must match\n(a logical AND). If the count is 1, at least one entry must match (a logical OR). If the count contains a\nvalue N, then N must be less than or equal to the size of entries, and at least N entries must match.",
+                              "minimum": 1,
+                              "type": "integer"
+                            },
+                            "entries": {
+                              "description": "Entries contains the available attestors. An attestor can be a static key,\nattributes for keyless verification, or a nested attestor declaration.",
+                              "items": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "Annotations are used for image verification.\nEvery specified key-value pair must exist and match in the verified payload.\nThe payload may contain other key-value pairs.",
+                                    "type": "object"
+                                  },
+                                  "attestor": {
+                                    "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "certificates": {
+                                    "description": "Certificates specifies one or more certificates.",
+                                    "properties": {
+                                      "cert": {
+                                        "description": "Cert is an optional PEM-encoded public certificate.",
+                                        "type": "string"
+                                      },
+                                      "certChain": {
+                                        "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
+                                        "type": "string"
+                                      },
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "rekor": {
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "keyless": {
+                                    "description": "Keyless is a set of attribute used to verify a Sigstore keyless attestor.\nSee https://github.com/sigstore/cosign/blob/main/KEYLESS.md.",
+                                    "properties": {
+                                      "additionalExtensions": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
+                                        "type": "object"
+                                      },
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "issuer": {
+                                        "description": "Issuer is the certificate issuer used for keyless signing.",
+                                        "type": "string"
+                                      },
+                                      "issuerRegExp": {
+                                        "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
+                                        "type": "string"
+                                      },
+                                      "rekor": {
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "roots": {
+                                        "description": "Roots is an optional set of PEM encoded trusted root certificates.\nIf not provided, the system roots are used.",
+                                        "type": "string"
+                                      },
+                                      "subject": {
+                                        "description": "Subject is the verified identity used for keyless signing, for example the email address.",
+                                        "type": "string"
+                                      },
+                                      "subjectRegExp": {
+                                        "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "keys": {
+                                    "description": "Keys specifies one or more public keys.",
+                                    "properties": {
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          },
+                                          "tsaCertChain": {
+                                            "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "kms": {
+                                        "description": "KMS provides the URI to the public key stored in a Key Management System. See:\nhttps://github.com/sigstore/cosign/blob/main/KMS.md",
+                                        "type": "string"
+                                      },
+                                      "publicKeys": {
+                                        "description": "Keys is a set of X.509 public keys used to verify image signatures. The keys can be directly\nspecified or can be a variable reference to a key specified in a ConfigMap (see\nhttps://kyverno.io/docs/writing-policies/variables/), or reference a standard Kubernetes Secret\nelsewhere in the cluster by specifying it in the format \"k8s://<namespace>/<secret_name>\".\nThe named Secret must specify a key `cosign.pub` containing the public key used for\nverification, (see https://github.com/sigstore/cosign/blob/main/KMS.md#kubernetes-secret).\nWhen multiple keys are specified each key is processed as a separate staticKey entry\n(.attestors[*].entries.keys) within the set of attestors and the count is applied across the keys.",
+                                        "type": "string"
+                                      },
+                                      "rekor": {
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "secret": {
+                                        "description": "Reference to a Secret resource that contains a public key",
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of the secret. The provided secret must contain a key named cosign.pub.",
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace name where the Secret exists.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "namespace"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "repository": {
+                                    "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                    "type": "string"
+                                  },
+                                  "signatureAlgorithm": {
+                                    "default": "sha256",
+                                    "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "dryRun": {
+                        "description": "DryRun configuration",
+                        "properties": {
+                          "enable": {
+                            "type": "boolean"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "ignoreFields": {
+                        "description": "Fields which will be ignored while comparing manifests.",
+                        "items": {
+                          "properties": {
+                            "fields": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "objects": {
+                              "items": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "repository": {
+                        "description": "Repository is an optional alternate OCI repository to use for resource bundle reference.\nThe repository can be overridden per Attestor or Attestation.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "message": {
+                    "description": "Message specifies a custom message to be displayed on failure.",
+                    "type": "string"
+                  },
+                  "pattern": {
+                    "description": "Pattern specifies an overlay-style pattern used to check resources.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "podSecurity": {
+                    "description": "PodSecurity applies exemptions for Kubernetes Pod Security admission\nby specifying exclusions for Pod Security Standards controls.",
+                    "properties": {
+                      "exclude": {
+                        "description": "Exclude specifies the Pod Security Standard controls to be excluded.",
+                        "items": {
+                          "description": "PodSecurityStandard specifies the Pod Security Standard controls to be excluded.",
+                          "properties": {
+                            "controlName": {
+                              "description": "ControlName specifies the name of the Pod Security Standard control.\nSee: https://kubernetes.io/docs/concepts/security/pod-security-standards/",
+                              "enum": [
+                                "HostProcess",
+                                "Host Namespaces",
+                                "Privileged Containers",
+                                "Capabilities",
+                                "HostPath Volumes",
+                                "Host Ports",
+                                "AppArmor",
+                                "SELinux",
+                                "/proc Mount Type",
+                                "Seccomp",
+                                "Sysctls",
+                                "Volume Types",
+                                "Privilege Escalation",
+                                "Running as Non-root",
+                                "Running as Non-root user"
+                              ],
+                              "type": "string"
+                            },
+                            "images": {
+                              "description": "Images selects matching containers and applies the container level PSS.\nEach image is the image name consisting of the registry address, repository, image, and tag.\nEmpty list matches no containers, PSS checks are applied at the pod level only.\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "restrictedField": {
+                              "description": "RestrictedField selects the field for the given Pod Security Standard control.\nWhen not set, all restricted fields for the control are selected.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "Values defines the allowed values that can be excluded.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "controlName"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "level": {
+                        "description": "Level defines the Pod Security Standard level to be applied to workloads.\nAllowed values are privileged, baseline, and restricted.",
+                        "enum": [
+                          "privileged",
+                          "baseline",
+                          "restricted"
+                        ],
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Version defines the Pod Security Standard versions that Kubernetes supports.\nAllowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, v1.27, v1.28, v1.29, v1.30, v1.31, v1.32, latest. Defaults to latest.",
+                        "enum": [
+                          "v1.19",
+                          "v1.20",
+                          "v1.21",
+                          "v1.22",
+                          "v1.23",
+                          "v1.24",
+                          "v1.25",
+                          "v1.26",
+                          "v1.27",
+                          "v1.28",
+                          "v1.29",
+                          "v1.30",
+                          "v1.31",
+                          "v1.32",
+                          "latest"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "verifyImages": {
+                "description": "VerifyImages is used to verify image signatures and mutate them to add a digest",
+                "items": {
+                  "description": "ImageVerification validates that images that match the specified pattern\nare signed with the supplied public key. Once the image is verified it is\nmutated to include the SHA digest retrieved during the registration.",
+                  "properties": {
+                    "additionalExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Deprecated.",
+                      "type": "object"
+                    },
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Deprecated. Use annotations per Attestor instead.",
+                      "type": "object"
+                    },
+                    "attestations": {
+                      "description": "Attestations are optional checks for signed in-toto Statements used to verify the image.\nSee https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the\nOCI registry and decodes them into a list of Statement declarations.",
+                      "items": {
+                        "description": "Attestation are checks for signed in-toto Statements that are used to verify the image.\nSee https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the\nOCI registry and decodes them into a list of Statements.",
+                        "properties": {
+                          "attestors": {
+                            "description": "Attestors specify the required attestors (i.e. authorities).",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "description": "Count specifies the required number of entries that must match. If the count is null, all entries must match\n(a logical AND). If the count is 1, at least one entry must match (a logical OR). If the count contains a\nvalue N, then N must be less than or equal to the size of entries, and at least N entries must match.",
+                                  "minimum": 1,
+                                  "type": "integer"
+                                },
+                                "entries": {
+                                  "description": "Entries contains the available attestors. An attestor can be a static key,\nattributes for keyless verification, or a nested attestor declaration.",
+                                  "items": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "Annotations are used for image verification.\nEvery specified key-value pair must exist and match in the verified payload.\nThe payload may contain other key-value pairs.",
+                                        "type": "object"
+                                      },
+                                      "attestor": {
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "certificates": {
+                                        "description": "Certificates specifies one or more certificates.",
+                                        "properties": {
+                                          "cert": {
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
+                                            "type": "string"
+                                          },
+                                          "certChain": {
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
+                                            "type": "string"
+                                          },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "keyless": {
+                                        "description": "Keyless is a set of attribute used to verify a Sigstore keyless attestor.\nSee https://github.com/sigstore/cosign/blob/main/KEYLESS.md.",
+                                        "properties": {
+                                          "additionalExtensions": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
+                                            "type": "object"
+                                          },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "issuer": {
+                                            "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "roots": {
+                                            "description": "Roots is an optional set of PEM encoded trusted root certificates.\nIf not provided, the system roots are used.",
+                                            "type": "string"
+                                          },
+                                          "subject": {
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
+                                            "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "keys": {
+                                        "description": "Keys specifies one or more public keys.",
+                                        "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kms": {
+                                            "description": "KMS provides the URI to the public key stored in a Key Management System. See:\nhttps://github.com/sigstore/cosign/blob/main/KMS.md",
+                                            "type": "string"
+                                          },
+                                          "publicKeys": {
+                                            "description": "Keys is a set of X.509 public keys used to verify image signatures. The keys can be directly\nspecified or can be a variable reference to a key specified in a ConfigMap (see\nhttps://kyverno.io/docs/writing-policies/variables/), or reference a standard Kubernetes Secret\nelsewhere in the cluster by specifying it in the format \"k8s://<namespace>/<secret_name>\".\nThe named Secret must specify a key `cosign.pub` containing the public key used for\nverification, (see https://github.com/sigstore/cosign/blob/main/KMS.md#kubernetes-secret).\nWhen multiple keys are specified each key is processed as a separate staticKey entry\n(.attestors[*].entries.keys) within the set of attestors and the count is applied across the keys.",
+                                            "type": "string"
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "secret": {
+                                            "description": "Reference to a Secret resource that contains a public key",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the secret. The provided secret must contain a key named cosign.pub.",
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace name where the Secret exists.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "namespace"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "signatureAlgorithm": {
+                                            "default": "sha256",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "repository": {
+                                        "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "conditions": {
+                            "description": "Conditions are used to verify attributes within a Predicate. If no Conditions are specified\nthe attestation check is satisfied as long there are predicates that match the predicate type.",
+                            "items": {
+                              "description": "AnyAllConditions consists of conditions wrapped denoting a logical criteria to be fulfilled.\nAnyConditions get fulfilled when at least one of its sub-conditions passes.\nAllConditions get fulfilled only when all of its sub-conditions pass.",
+                              "properties": {
+                                "all": {
+                                  "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "any": {
+                                  "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is the variable name.",
+                            "type": "string"
+                          },
+                          "predicateType": {
+                            "description": "Deprecated in favour of 'Type', to be removed soon",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type defines the type of attestation contained within the Statement.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "attestors": {
+                      "description": "Attestors specified the required attestors (i.e. authorities)",
+                      "items": {
+                        "properties": {
+                          "count": {
+                            "description": "Count specifies the required number of entries that must match. If the count is null, all entries must match\n(a logical AND). If the count is 1, at least one entry must match (a logical OR). If the count contains a\nvalue N, then N must be less than or equal to the size of entries, and at least N entries must match.",
+                            "minimum": 1,
+                            "type": "integer"
+                          },
+                          "entries": {
+                            "description": "Entries contains the available attestors. An attestor can be a static key,\nattributes for keyless verification, or a nested attestor declaration.",
+                            "items": {
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations are used for image verification.\nEvery specified key-value pair must exist and match in the verified payload.\nThe payload may contain other key-value pairs.",
+                                  "type": "object"
+                                },
+                                "attestor": {
+                                  "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "certificates": {
+                                  "description": "Certificates specifies one or more certificates.",
+                                  "properties": {
+                                    "cert": {
+                                      "description": "Cert is an optional PEM-encoded public certificate.",
+                                      "type": "string"
+                                    },
+                                    "certChain": {
+                                      "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
+                                      "type": "string"
+                                    },
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "rekor": {
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "keyless": {
+                                  "description": "Keyless is a set of attribute used to verify a Sigstore keyless attestor.\nSee https://github.com/sigstore/cosign/blob/main/KEYLESS.md.",
+                                  "properties": {
+                                    "additionalExtensions": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
+                                      "type": "object"
+                                    },
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "issuer": {
+                                      "description": "Issuer is the certificate issuer used for keyless signing.",
+                                      "type": "string"
+                                    },
+                                    "issuerRegExp": {
+                                      "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
+                                      "type": "string"
+                                    },
+                                    "rekor": {
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "roots": {
+                                      "description": "Roots is an optional set of PEM encoded trusted root certificates.\nIf not provided, the system roots are used.",
+                                      "type": "string"
+                                    },
+                                    "subject": {
+                                      "description": "Subject is the verified identity used for keyless signing, for example the email address.",
+                                      "type": "string"
+                                    },
+                                    "subjectRegExp": {
+                                      "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "keys": {
+                                  "description": "Keys specifies one or more public keys.",
+                                  "properties": {
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        },
+                                        "tsaCertChain": {
+                                          "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "kms": {
+                                      "description": "KMS provides the URI to the public key stored in a Key Management System. See:\nhttps://github.com/sigstore/cosign/blob/main/KMS.md",
+                                      "type": "string"
+                                    },
+                                    "publicKeys": {
+                                      "description": "Keys is a set of X.509 public keys used to verify image signatures. The keys can be directly\nspecified or can be a variable reference to a key specified in a ConfigMap (see\nhttps://kyverno.io/docs/writing-policies/variables/), or reference a standard Kubernetes Secret\nelsewhere in the cluster by specifying it in the format \"k8s://<namespace>/<secret_name>\".\nThe named Secret must specify a key `cosign.pub` containing the public key used for\nverification, (see https://github.com/sigstore/cosign/blob/main/KMS.md#kubernetes-secret).\nWhen multiple keys are specified each key is processed as a separate staticKey entry\n(.attestors[*].entries.keys) within the set of attestors and the count is applied across the keys.",
+                                      "type": "string"
+                                    },
+                                    "rekor": {
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "secret": {
+                                      "description": "Reference to a Secret resource that contains a public key",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Name of the secret. The provided secret must contain a key named cosign.pub.",
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "description": "Namespace name where the Secret exists.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "namespace"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "signatureAlgorithm": {
+                                      "default": "sha256",
+                                      "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "repository": {
+                                  "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                  "type": "string"
+                                },
+                                "signatureAlgorithm": {
+                                  "default": "sha256",
+                                  "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "cosignOCI11": {
+                      "description": "CosignOCI11 enables the experimental OCI 1.1 behaviour in cosign image verification.\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "failureAction": {
+                      "description": "Allowed values are Audit or Enforce.",
+                      "enum": [
+                        "Audit",
+                        "Enforce"
+                      ],
+                      "type": "string"
+                    },
+                    "image": {
+                      "description": "Deprecated. Use ImageReferences instead.",
+                      "type": "string"
+                    },
+                    "imageReferences": {
+                      "description": "ImageReferences is a list of matching image reference patterns. At least one pattern in the\nlist must match the image for the rule to apply. Each image reference consists of a registry\naddress (defaults to docker.io), repository, image, and tag (defaults to latest).\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "imageRegistryCredentials": {
+                      "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry.",
+                      "properties": {
+                        "allowInsecureRegistry": {
+                          "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                          "type": "boolean"
+                        },
+                        "providers": {
+                          "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                          "items": {
+                            "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                            "enum": [
+                              "default",
+                              "amazon",
+                              "azure",
+                              "google",
+                              "github"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secrets": {
+                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "issuer": {
+                      "description": "Deprecated. Use KeylessAttestor instead.",
+                      "type": "string"
+                    },
+                    "key": {
+                      "description": "Deprecated. Use StaticKeyAttestor instead.",
+                      "type": "string"
+                    },
+                    "mutateDigest": {
+                      "default": true,
+                      "description": "MutateDigest enables replacement of image tags with digests.\nDefaults to true.",
+                      "type": "boolean"
+                    },
+                    "repository": {
+                      "description": "Repository is an optional alternate OCI repository to use for image signatures and attestations that match this rule.\nIf specified Repository will override the default OCI image repository configured for the installation.\nThe repository can also be overridden per Attestor or Attestation.",
+                      "type": "string"
+                    },
+                    "required": {
+                      "default": true,
+                      "description": "Required validates that images are verified i.e. have matched passed a signature or attestation check.",
+                      "type": "boolean"
+                    },
+                    "roots": {
+                      "description": "Deprecated. Use KeylessAttestor instead.",
+                      "type": "string"
+                    },
+                    "skipImageReferences": {
+                      "description": "SkipImageReferences is a list of matching image reference patterns that should be skipped.\nAt least one pattern in the list must match the image for the rule to be skipped. Each image reference\nconsists of a registry address (defaults to docker.io), repository, image, and tag (defaults to latest).\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "subject": {
+                      "description": "Deprecated. Use KeylessAttestor instead.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type specifies the method of signature validation. The allowed options\nare Cosign, Sigstore Bundle and Notary. By default Cosign is used if a type is not specified.",
+                      "enum": [
+                        "Cosign",
+                        "SigstoreBundle",
+                        "Notary"
+                      ],
+                      "type": "string"
+                    },
+                    "useCache": {
+                      "default": true,
+                      "description": "UseCache enables caching of image verify responses for this rule.",
+                      "type": "boolean"
+                    },
+                    "validate": {
+                      "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                      "properties": {
+                        "deny": {
+                          "description": "Deny defines conditions used to pass or fail a validation rule.",
+                          "properties": {
+                            "conditions": {
+                              "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "message": {
+                          "description": "Message specifies a custom message to be displayed on failure.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "verifyDigest": {
+                      "default": true,
+                      "description": "VerifyDigest validates that images have a digest.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "match",
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "schemaValidation": {
+          "description": "Deprecated.",
+          "type": "boolean"
+        },
+        "useServerSideApply": {
+          "description": "UseServerSideApply controls whether to use server-side apply for generate rules\nIf is set to \"true\" create & update for generate rules will use apply instead of create/update.\nDefaults to \"false\" if not specified.",
+          "type": "boolean"
+        },
+        "validationFailureAction": {
+          "default": "Audit",
+          "description": "Deprecated, use validationFailureAction under the validate rule instead.",
+          "enum": [
+            "audit",
+            "enforce",
+            "Audit",
+            "Enforce"
+          ],
+          "type": "string"
+        },
+        "validationFailureActionOverrides": {
+          "description": "Deprecated, use validationFailureActionOverrides under the validate rule instead.",
+          "items": {
+            "properties": {
+              "action": {
+                "description": "ValidationFailureAction defines the policy validation failure action",
+                "enum": [
+                  "audit",
+                  "enforce",
+                  "Audit",
+                  "Enforce"
+                ],
+                "type": "string"
+              },
+              "namespaceSelector": {
+                "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic"
+              },
+              "namespaces": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "webhookConfiguration": {
+          "description": "WebhookConfiguration specifies the custom configuration for Kubernetes admission webhookconfiguration.",
+          "properties": {
+            "failurePolicy": {
+              "description": "FailurePolicy defines how unexpected policy errors and webhook response timeout errors are handled.\nRules within the same policy share the same failure behavior.\nThis field should not be accessed directly, instead `GetFailurePolicy()` should be used.\nAllowed values are Ignore or Fail. Defaults to Fail.",
+              "enum": [
+                "Ignore",
+                "Fail"
+              ],
+              "type": "string"
+            },
+            "matchConditions": {
+              "description": "MatchCondition configures admission webhook matchConditions.\nRequires Kubernetes 1.27 or later.",
+              "items": {
+                "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                "properties": {
+                  "expression": {
+                    "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "expression",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "timeoutSeconds": {
+              "description": "TimeoutSeconds specifies the maximum time in seconds allowed to apply this policy.\nAfter the configured time expires, the admission request may fail, or may simply ignore the policy results,\nbased on the failure policy. The default timeout is 10s, the value must be between 1 and 30 seconds.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "webhookTimeoutSeconds": {
+          "description": "Deprecated, use webhookTimeoutSeconds under webhookConfiguration instead.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "Status contains policy runtime data.",
+      "properties": {
+        "autogen": {
+          "description": "AutogenStatus contains autogen status information.",
+          "properties": {
+            "rules": {
+              "description": "Rules is a list of Rule instances. It contains auto generated rules added for pod controllers",
+              "items": {
+                "description": "Rule defines a validation, mutation, or generation control for matching resources.\nEach rules contains a match declaration to select resources, and an optional exclude\ndeclaration to specify which resources to exclude.",
+                "properties": {
+                  "celPreconditions": {
+                    "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a\nset of CEL conditions. It can only be used with the validate.cel subrule",
+                    "items": {
+                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "properties": {
+                        "expression": {
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.\nCEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:\n\n'object' - The object from the incoming request. The value is null for DELETE requests.\n'oldObject' - The existing object. The value is null for CREATE requests.\n'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).\n'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\nDocumentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/\n\nRequired.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions,\nas well as providing an identifier for logging purposes. A good name should be descriptive of\nthe associated expression.\nName must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and\nmust start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or\n'123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an\noptional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')\n\nRequired.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "expression",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "context": {
+                    "description": "Context defines variables and data sources that can be used during rule execution.",
+                    "items": {
+                      "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "configMap"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "apiCall"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "imageRegistry"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "variable"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "globalReference"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "apiCall": {
+                          "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                          "properties": {
+                            "data": {
+                              "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                              "items": {
+                                "description": "RequestData contains the HTTP POST data",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is a unique identifier for the data value",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the data value",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "default": {
+                              "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "jmesPath": {
+                              "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                              "type": "string"
+                            },
+                            "method": {
+                              "default": "GET",
+                              "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                              "enum": [
+                                "GET",
+                                "POST"
+                              ],
+                              "type": "string"
+                            },
+                            "service": {
+                              "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                              "properties": {
+                                "caBundle": {
+                                  "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                  "type": "string"
+                                },
+                                "headers": {
+                                  "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the header key",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the header value",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "value"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "url": {
+                                  "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object"
+                            },
+                            "urlPath": {
+                              "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "configMap": {
+                          "description": "ConfigMap is the ConfigMap reference.",
+                          "properties": {
+                            "name": {
+                              "description": "Name is the ConfigMap name.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the ConfigMap namespace.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "globalReference": {
+                          "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                          "properties": {
+                            "jmesPath": {
+                              "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the global context entry",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        "imageRegistry": {
+                          "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                          "properties": {
+                            "imageRegistryCredentials": {
+                              "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                              "properties": {
+                                "allowInsecureRegistry": {
+                                  "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                  "type": "boolean"
+                                },
+                                "providers": {
+                                  "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                  "items": {
+                                    "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                    "enum": [
+                                      "default",
+                                      "amazon",
+                                      "azure",
+                                      "google",
+                                      "github"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "secrets": {
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "jmesPath": {
+                              "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                              "type": "string"
+                            },
+                            "reference": {
+                              "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "reference"
+                          ],
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "Name is the variable name.",
+                          "type": "string"
+                        },
+                        "variable": {
+                          "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                          "properties": {
+                            "default": {
+                              "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "jmesPath": {
+                              "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "exclude": {
+                    "description": "ExcludeResources defines when this policy rule should not be applied. The exclude\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the name or role.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
+                    "properties": {
+                      "all": {
+                        "description": "All allows specifying resources which will be ANDed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "any": {
+                        "description": "Any allows specifying resources which will be ORed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "clusterRoles": {
+                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                            "type": "object"
+                          },
+                          "kinds": {
+                            "description": "Kinds is a list of resource kinds.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                            "type": "string"
+                          },
+                          "names": {
+                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namespaceSelector": {
+                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "namespaces": {
+                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "selector": {
+                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "roles": {
+                        "description": "Roles is the list of namespaced role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "subjects": {
+                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                        "items": {
+                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the object being referenced.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "generate": {
+                    "description": "Generation is used to create new resources.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "APIVersion specifies resource apiVersion.",
+                        "type": "string"
+                      },
+                      "clone": {
+                        "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                        "properties": {
+                          "name": {
+                            "description": "Name specifies name of the resource.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace specifies source resource namespace.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "cloneList": {
+                        "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                        "properties": {
+                          "kinds": {
+                            "description": "Kinds is a list of resource kinds.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namespace": {
+                            "description": "Namespace specifies source resource namespace.",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "data": {
+                        "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "foreach": {
+                        "description": "ForEach applies generate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "items": {
+                          "properties": {
+                            "apiVersion": {
+                              "description": "APIVersion specifies resource apiVersion.",
+                              "type": "string"
+                            },
+                            "clone": {
+                              "description": "Clone specifies the source resource used to populate each generated resource.\nAt most one of Data or Clone can be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name specifies name of the resource.",
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "cloneList": {
+                              "description": "CloneList specifies the list of source resource used to populate each generated resource.",
+                              "properties": {
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespace": {
+                                  "description": "Namespace specifies source resource namespace.",
+                                  "type": "string"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels`.\nwildcard characters are not supported.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "globalReference": {
+                                    "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                    "properties": {
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the global context entry",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "data": {
+                              "description": "Data provides the resource declaration used to populate each generated resource.\nAt most one of Data or Clone must be specified. If neither are provided, the generated\nresource will be created with default data only.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "kind": {
+                              "description": "Kind specifies resource kind.",
+                              "type": "string"
+                            },
+                            "list": {
+                              "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name specifies the resource name.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "properties": {
+                                "all": {
+                                  "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "any": {
+                                  "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "generateExisting": {
+                        "description": "GenerateExisting controls whether to trigger the rule in existing resources\nIf is set to \"true\" the rule will be triggered and applied to existing matched resources.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind specifies resource kind.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name specifies the resource name.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace specifies resource namespace.",
+                        "type": "string"
+                      },
+                      "orphanDownstreamOnPolicyDelete": {
+                        "description": "OrphanDownstreamOnPolicyDelete controls whether generated resources should be deleted when the rule that generated\nthem is deleted with synchronization enabled. This option is only applicable to generate rules of the data type.\nSee https://kyverno.io/docs/writing-policies/generate/#data-examples.\nDefaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "synchronize": {
+                        "description": "Synchronize controls if generated resources should be kept in-sync with their source resource.\nIf Synchronize is set to \"true\" changes to generated resources will be overwritten with resource\ndata from Data or the resource specified in the Clone declaration.\nOptional. Defaults to \"false\" if not specified.",
+                        "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "imageExtractors": {
+                    "additionalProperties": {
+                      "items": {
+                        "properties": {
+                          "jmesPath": {
+                            "description": "JMESPath is an optional JMESPath expression to apply to the image value.\nThis is useful when the extracted image begins with a prefix like 'docker://'.\nThe 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://').\nNote - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image.\nNote - this field MUST be unique.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name is the entry the image will be available under 'images.<name>' in the context.\nIf this field is not defined, image entries will appear under 'images.custom'.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "Path is the path to the object containing the image field in a custom resource.\nIt should be slash-separated. Each slash-separated key must be a valid YAML key or a wildcard '*'.\nWildcard keys are expanded in case of arrays or objects.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is an optional name of the field within 'path' that points to the image URI.\nThis is useful when a custom 'key' is also defined.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "description": "ImageExtractors defines a mapping from kinds to ImageExtractorConfigs.\nThis config is only valid for verifyImages rules.",
+                    "type": "object"
+                  },
+                  "match": {
+                    "description": "MatchResources defines when this policy rule should be applied. The match\ncriteria can include resource information (e.g. kind, name, namespace, labels)\nand admission review request information like the user name or role.\nAt least one kind is required.",
+                    "not": {
+                      "required": [
+                        "any",
+                        "all"
+                      ]
+                    },
+                    "properties": {
+                      "all": {
+                        "description": "All allows specifying resources which will be ANDed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "any": {
+                        "description": "Any allows specifying resources which will be ORed",
+                        "items": {
+                          "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                          "properties": {
+                            "clusterRoles": {
+                              "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "description": "ResourceDescription contains information about the resource being created or modified.",
+                              "not": {
+                                "required": [
+                                  "name",
+                                  "names"
+                                ]
+                              },
+                              "properties": {
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                                  "type": "object"
+                                },
+                                "kinds": {
+                                  "description": "Kinds is a list of resource kinds.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                                  "type": "string"
+                                },
+                                "names": {
+                                  "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "namespaceSelector": {
+                                  "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "namespaces": {
+                                  "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "selector": {
+                                  "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "roles": {
+                              "description": "Roles is the list of namespaced role names for the user.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "subjects": {
+                              "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                              "items": {
+                                "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the object being referenced.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "clusterRoles": {
+                        "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "description": "ResourceDescription contains information about the resource being created or modified.\nRequires at least one tag to be specified when under MatchResources.\nSpecifying ResourceDescription directly under match is being deprecated.\nPlease specify under \"any\" or \"all\" instead.",
+                        "not": {
+                          "required": [
+                            "name",
+                            "names"
+                          ]
+                        },
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys\nand values support the wildcard characters \"*\" (matches zero or many characters) and\n\"?\" (matches at least one character).",
+                            "type": "object"
+                          },
+                          "kinds": {
+                            "description": "Kinds is a list of resource kinds.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "Name is the name of the resource. The name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).\nNOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                            "type": "string"
+                          },
+                          "names": {
+                            "description": "Names are the names of the resources. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "namespaceSelector": {
+                            "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values\nin `matchLabels` support the wildcard characters `*` (matches zero or many characters)\nand `?` (matches one character).Wildcards allows writing label selectors like\n[\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but\ndoes not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "namespaces": {
+                            "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters\n\"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "selector": {
+                            "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard\ncharacters `*` (matches zero or many characters) and `?` (matches one character).\nWildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that\nusing [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "roles": {
+                        "description": "Roles is the list of namespaced role names for the user.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "subjects": {
+                        "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                        "items": {
+                          "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,\nor a value for non-objects such as user and group names.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup holds the API group of the referenced subject.\nDefaults to \"\" for ServiceAccount subjects.\nDefaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\".\nIf the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the object being referenced.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty\nthe Authorizer should report an error.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "mutate": {
+                    "description": "Mutation is used to modify matching resources.",
+                    "properties": {
+                      "foreach": {
+                        "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "items": {
+                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "properties": {
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "globalReference": {
+                                    "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                    "properties": {
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the global context entry",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "foreach": {
+                              "description": "Foreach declares a nested foreach iterator",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "list": {
+                              "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                              "type": "string"
+                            },
+                            "order": {
+                              "description": "Order defines the iteration order on the list.\nCan be Ascending to iterate from first to last element or Descending to iterate in from last to first element.",
+                              "enum": [
+                                "Ascending",
+                                "Descending"
+                              ],
+                              "type": "string"
+                            },
+                            "patchStrategicMerge": {
+                              "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "patchesJson6902": {
+                              "description": "PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources.\nSee https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "properties": {
+                                "all": {
+                                  "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "any": {
+                                  "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "mutateExistingOnPolicyUpdate": {
+                        "description": "MutateExistingOnPolicyUpdate controls if the mutateExisting rule will be applied on policy events.",
+                        "type": "boolean"
+                      },
+                      "patchStrategicMerge": {
+                        "description": "PatchStrategicMerge is a strategic merge patch used to modify resources.\nSee https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/\nand https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "patchesJson6902": {
+                        "description": "PatchesJSON6902 is a list of RFC 6902 JSON Patch declarations used to modify resources.\nSee https://tools.ietf.org/html/rfc6902 and https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/.",
+                        "type": "string"
+                      },
+                      "targets": {
+                        "description": "Targets defines the target resources to be mutated.",
+                        "items": {
+                          "description": "TargetResourceSpec defines targets for mutating existing resources.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "APIVersion specifies resource apiVersion.",
+                              "type": "string"
+                            },
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "globalReference": {
+                                    "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                    "properties": {
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the global context entry",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "kind": {
+                              "description": "Kind specifies resource kind.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name specifies the resource name.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "selector": {
+                              "description": "Selector allows you to select target resources with their labels.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "name": {
+                    "description": "Name is a label to identify the rule, It must be unique within the policy.",
+                    "maxLength": 63,
+                    "type": "string"
+                  },
+                  "preconditions": {
+                    "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements. A direct list\nof conditions (without `any` or `all` statements is supported for backwards compatibility but\nwill be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "reportProperties": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "ReportProperties are the additional properties from the rule that will be added to the policy report result",
+                    "type": "object"
+                  },
+                  "skipBackgroundRequests": {
+                    "default": true,
+                    "description": "SkipBackgroundRequests bypasses admission requests that are sent by the background controller.\nThe default value is set to \"true\", it must be set to \"false\" to apply\ngenerate and mutateExisting rules to those requests.",
+                    "type": "boolean"
+                  },
+                  "validate": {
+                    "description": "Validation is used to validate matching resources.",
+                    "properties": {
+                      "allowExistingViolations": {
+                        "default": true,
+                        "description": "AllowExistingViolations allows prexisting violating resources to continue violating a policy.",
+                        "type": "boolean"
+                      },
+                      "anyPattern": {
+                        "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "assert": {
+                        "description": "Assert defines a kyverno-json assertion tree.",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "cel": {
+                        "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                        "properties": {
+                          "auditAnnotations": {
+                            "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                            "items": {
+                              "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                              "properties": {
+                                "key": {
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of\na ValidatingAdmissionPolicy must be unique. The key must be a qualified\nname ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.\n\nThe key is combined with the resource name of the\nValidatingAdmissionPolicy to construct an audit annotation key:\n\"{ValidatingAdmissionPolicy name}/{key}\".\n\nIf an admission webhook uses the same resource name as this ValidatingAdmissionPolicy\nand the same audit annotation key, the annotation key will be identical.\nIn this case, the first annotation written with the key will be included\nin the audit event and all subsequent annotations with the same key\nwill be discarded.\n\nRequired.",
+                                  "type": "string"
+                                },
+                                "valueExpression": {
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to\nproduce an audit annotation value. The expression must evaluate to either\na string or null value. If the expression evaluates to a string, the\naudit annotation is included with the string value. If the expression\nevaluates to null or empty string the audit annotation will be omitted.\nThe valueExpression may be no longer than 5kb in length.\nIf the result of the valueExpression is more than 10kb in length, it\nwill be truncated to 10kb.\n\nIf multiple ValidatingAdmissionPolicyBinding resources match an\nAPI request, then the valueExpression will be evaluated for\neach binding. All unique values produced by the valueExpressions\nwill be joined together in a comma-separated list.\n\nRequired.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "valueExpression"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "expressions": {
+                            "description": "Expressions is a list of CELExpression types.",
+                            "items": {
+                              "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression represents the expression which will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nCEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:\n\n- 'object' - The object from the incoming request. The value is null for DELETE requests.\n- 'oldObject' - The existing object. The value is null for CREATE requests.\n- 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)).\n- 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind.\n- 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.\n- 'variables' - Map of composited variables, from its name to its lazily evaluated value.\n  For example, a variable named 'foo' can be accessed as 'variables.foo'.\n- 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.\n  See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz\n- 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the\n  request resource.\n\nThe `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the\nobject. No other metadata properties are accessible.\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible.\nAccessible property names are escaped according to the following rules when accessed in the expression:\n- '__' escapes to '__underscores__'\n- '.' escapes to '__dot__'\n- '-' escapes to '__dash__'\n- '/' escapes to '__slash__'\n- Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:\n\t  \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\",\n\t  \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\".\nExamples:\n  - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"}\n  - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"}\n  - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"}\n\nEquality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1].\nConcatenation on arrays with x-kubernetes-list-type use the semantics of the list type:\n  - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and\n    non-intersecting elements in `Y` are appended, retaining their partial order.\n  - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values\n    are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with\n    non-intersecting keys are appended, retaining their partial order.\nRequired.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains\nline breaks. The message must not contain line breaks.\nIf unset, the message is \"failed rule: {Rule}\".\ne.g. \"must be a URL with the host matching spec.host\"\nIf the Expression contains line breaks. Message is required.\nThe message must not contain line breaks.\nIf unset, the message is \"failed Expression: {Expression}\".",
+                                  "type": "string"
+                                },
+                                "messageExpression": {
+                                  "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.\nSince messageExpression is used as a failure message, it must evaluate to a string.\nIf both message and messageExpression are present on a validation, then messageExpression will be used if validation fails.\nIf messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced\nas if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string\nthat contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and\nthe fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged.\nmessageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'.\nExample:\n\"object.x must be less than max (\"+string(params.max)+\")\"",
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "description": "Reason represents a machine-readable description of why this validation failed.\nIf this is the first validation in the list to fail, this reason, as well as the\ncorresponding HTTP response code, are used in the\nHTTP response to the client.\nThe currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\".\nIf not set, StatusReasonInvalid is used in the response to the client.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "generate": {
+                            "default": false,
+                            "description": "Generate specifies whether to generate a Kubernetes ValidatingAdmissionPolicy from the rule.\nOptional. Defaults to \"false\" if not specified.",
+                            "type": "boolean"
+                          },
+                          "paramKind": {
+                            "description": "ParamKind is a tuple of Group Kind and Version.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "APIVersion is the API group version the resources belong to.\nIn format of \"group/version\".\nRequired.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the API kind the resources belong to.\nRequired.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "paramRef": {
+                            "description": "ParamRef references a parameter resource.",
+                            "properties": {
+                              "name": {
+                                "description": "name is the name of the resource being referenced.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.\n\nA single parameter used for all admission requests can be configured\nby setting the `name` field, leaving `selector` blank, and setting namespace\nif `paramKind` is namespace-scoped.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting\nthe search for params to a specific namespace. Applies to both `name` and\n`selector` fields.\n\nA per-namespace parameter may be used by specifying a namespace-scoped\n`paramKind` in the policy and leaving this field empty.\n\n- If `paramKind` is cluster-scoped, this field MUST be unset. Setting this\nfield results in a configuration error.\n\n- If `paramKind` is namespace-scoped, the namespace of the object being\nevaluated for admission will be used when this field is left unset. Take\ncare that if this is left empty the binding must not match any cluster-scoped\nresources, which will result in an error.",
+                                "type": "string"
+                              },
+                              "parameterNotFoundAction": {
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource\nexists, and name or selector is valid, but there are no parameters\nmatched by the binding. If the value is set to `Allow`, then no\nmatched parameters will be treated as successful validation by the binding.\nIf set to `Deny`, then no matched parameters will be subject to the\n`failurePolicy` of the policy.\n\nAllowed values are `Allow` or `Deny`\n\nRequired",
+                                "type": "string"
+                              },
+                              "selector": {
+                                "description": "selector can be used to match multiple param objects based on their labels.\nSupply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions\nand the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are\nmutually exclusive properties. If one is set, the other must be unset.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "variables": {
+                            "description": "Variables contain definitions of variables that can be used in composition of other expressions.\nEach variable is defined as a named CEL expression.\nThe variables defined here will be available under `variables` in other expressions of the policy.",
+                            "items": {
+                              "description": "Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression is the expression that will be evaluated as the value of the variable.\nThe CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables.\nThe variable can be accessed in other expressions through `variables`\nFor example, if name is \"foo\", the variable will be available as `variables.foo`",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression",
+                                "name"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "deny": {
+                        "description": "Deny defines conditions used to pass or fail a validation rule.",
+                        "properties": {
+                          "conditions": {
+                            "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "failureAction": {
+                        "description": "FailureAction defines if a validation policy rule violation should block\nthe admission review request (Enforce), or allow (Audit) the admission review request\nand report an error in a policy report. Optional.\nAllowed values are Audit or Enforce.",
+                        "enum": [
+                          "Audit",
+                          "Enforce"
+                        ],
+                        "type": "string"
+                      },
+                      "failureActionOverrides": {
+                        "description": "FailureActionOverrides is a Cluster Policy attribute that specifies FailureAction\nnamespace-wise. It overrides FailureAction for the specified namespaces.",
+                        "items": {
+                          "properties": {
+                            "action": {
+                              "description": "ValidationFailureAction defines the policy validation failure action",
+                              "enum": [
+                                "audit",
+                                "enforce",
+                                "Audit",
+                                "Enforce"
+                              ],
+                              "type": "string"
+                            },
+                            "namespaceSelector": {
+                              "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "namespaces": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "foreach": {
+                        "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                        "items": {
+                          "description": "ForEachValidation applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "properties": {
+                            "anyPattern": {
+                              "description": "AnyPattern specifies list of validation patterns. At least one of the patterns\nmust be satisfied for the validation rule to succeed.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a\nConfigMap reference or a APILookup must be provided.",
+                                "oneOf": [
+                                  {
+                                    "required": [
+                                      "configMap"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "apiCall"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "imageRegistry"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "variable"
+                                    ]
+                                  },
+                                  {
+                                    "required": [
+                                      "globalReference"
+                                    ]
+                                  }
+                                ],
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service.\nThe data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "The data object specifies the POST data sent to the server.\nOnly applicable when the method field is set to POST.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the context\nvalue is set to, if the apiCall returns error.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST). Defaults to GET.",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service.\nThis is used for non-Kubernetes API server calls.\nIt's mutually exclusive with the URLPath field.",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate\nthe server certificate.",
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "description": "Headers is a list of optional HTTP headers to be included in the request.",
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "description": "Key is the header key",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "Value is the header value",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "value"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is\n`https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the\nKubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\").\nThe format required is the same format used by the `kubectl get --raw` command.\nSee https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls\nfor details.\nIt's mutually exclusive with the Service field.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "globalReference": {
+                                    "description": "GlobalContextEntryReference is a reference to a cached global context entry.",
+                                    "properties": {
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the JSON response returned from the server. For example\na JMESPath of \"items | length(@)\" applied to the API server response\nfor the URLPath \"/apis/apps/v1/deployments\" will return the total count\nof deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the global context entry",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image\ndetails.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to\ntransform the ImageData struct returned as a result of processing\nthe image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry.\nExample: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath\nexpression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to\ntransform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            "deny": {
+                              "description": "Deny defines conditions used to pass or fail a validation rule.",
+                              "properties": {
+                                "conditions": {
+                                  "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "elementScope": {
+                              "description": "ElementScope specifies whether to use the current list element as the scope for validation. Defaults to \"true\" if not specified.\nWhen set to \"false\", \"request.object\" is used as the validation scope within the foreach\nblock to allow referencing other elements in the subtree.",
+                              "type": "boolean"
+                            },
+                            "foreach": {
+                              "description": "Foreach declares a nested foreach iterator",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "list": {
+                              "description": "List specifies a JMESPath expression that results in one or more elements\nto which the validation logic is applied.",
+                              "type": "string"
+                            },
+                            "pattern": {
+                              "description": "Pattern specifies an overlay-style pattern used to check resources.",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "preconditions": {
+                              "description": "AnyAllConditions are used to determine if a policy rule should be applied by evaluating a\nset of conditions. The declaration can contain nested `any` or `all` statements.\nSee: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "properties": {
+                                "all": {
+                                  "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "any": {
+                                  "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                  "items": {
+                                    "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                        "enum": [
+                                          "Equals",
+                                          "NotEquals",
+                                          "In",
+                                          "AnyIn",
+                                          "AllIn",
+                                          "NotIn",
+                                          "AnyNotIn",
+                                          "AllNotIn",
+                                          "GreaterThanOrEquals",
+                                          "GreaterThan",
+                                          "LessThanOrEquals",
+                                          "LessThan",
+                                          "DurationGreaterThanOrEquals",
+                                          "DurationGreaterThan",
+                                          "DurationLessThanOrEquals",
+                                          "DurationLessThan"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "manifests": {
+                        "description": "Manifest specifies conditions for manifest verification",
+                        "properties": {
+                          "annotationDomain": {
+                            "description": "AnnotationDomain is custom domain of annotation for message and signature. Default is \"cosign.sigstore.dev\".",
+                            "type": "string"
+                          },
+                          "attestors": {
+                            "description": "Attestors specified the required attestors (i.e. authorities)",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "description": "Count specifies the required number of entries that must match. If the count is null, all entries must match\n(a logical AND). If the count is 1, at least one entry must match (a logical OR). If the count contains a\nvalue N, then N must be less than or equal to the size of entries, and at least N entries must match.",
+                                  "minimum": 1,
+                                  "type": "integer"
+                                },
+                                "entries": {
+                                  "description": "Entries contains the available attestors. An attestor can be a static key,\nattributes for keyless verification, or a nested attestor declaration.",
+                                  "items": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "Annotations are used for image verification.\nEvery specified key-value pair must exist and match in the verified payload.\nThe payload may contain other key-value pairs.",
+                                        "type": "object"
+                                      },
+                                      "attestor": {
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "certificates": {
+                                        "description": "Certificates specifies one or more certificates.",
+                                        "properties": {
+                                          "cert": {
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
+                                            "type": "string"
+                                          },
+                                          "certChain": {
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
+                                            "type": "string"
+                                          },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "keyless": {
+                                        "description": "Keyless is a set of attribute used to verify a Sigstore keyless attestor.\nSee https://github.com/sigstore/cosign/blob/main/KEYLESS.md.",
+                                        "properties": {
+                                          "additionalExtensions": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
+                                            "type": "object"
+                                          },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "issuer": {
+                                            "description": "Issuer is the certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "issuerRegExp": {
+                                            "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
+                                            "type": "string"
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "roots": {
+                                            "description": "Roots is an optional set of PEM encoded trusted root certificates.\nIf not provided, the system roots are used.",
+                                            "type": "string"
+                                          },
+                                          "subject": {
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
+                                            "type": "string"
+                                          },
+                                          "subjectRegExp": {
+                                            "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "keys": {
+                                        "description": "Keys specifies one or more public keys.",
+                                        "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              },
+                                              "tsaCertChain": {
+                                                "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "kms": {
+                                            "description": "KMS provides the URI to the public key stored in a Key Management System. See:\nhttps://github.com/sigstore/cosign/blob/main/KMS.md",
+                                            "type": "string"
+                                          },
+                                          "publicKeys": {
+                                            "description": "Keys is a set of X.509 public keys used to verify image signatures. The keys can be directly\nspecified or can be a variable reference to a key specified in a ConfigMap (see\nhttps://kyverno.io/docs/writing-policies/variables/), or reference a standard Kubernetes Secret\nelsewhere in the cluster by specifying it in the format \"k8s://<namespace>/<secret_name>\".\nThe named Secret must specify a key `cosign.pub` containing the public key used for\nverification, (see https://github.com/sigstore/cosign/blob/main/KMS.md#kubernetes-secret).\nWhen multiple keys are specified each key is processed as a separate staticKey entry\n(.attestors[*].entries.keys) within the set of attestors and the count is applied across the keys.",
+                                            "type": "string"
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "secret": {
+                                            "description": "Reference to a Secret resource that contains a public key",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the secret. The provided secret must contain a key named cosign.pub.",
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "description": "Namespace name where the Secret exists.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "namespace"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "signatureAlgorithm": {
+                                            "default": "sha256",
+                                            "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "repository": {
+                                        "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                        "type": "string"
+                                      },
+                                      "signatureAlgorithm": {
+                                        "default": "sha256",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "dryRun": {
+                            "description": "DryRun configuration",
+                            "properties": {
+                              "enable": {
+                                "type": "boolean"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "ignoreFields": {
+                            "description": "Fields which will be ignored while comparing manifests.",
+                            "items": {
+                              "properties": {
+                                "fields": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "objects": {
+                                  "items": {
+                                    "properties": {
+                                      "group": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "version": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "repository": {
+                            "description": "Repository is an optional alternate OCI repository to use for resource bundle reference.\nThe repository can be overridden per Attestor or Attestation.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "message": {
+                        "description": "Message specifies a custom message to be displayed on failure.",
+                        "type": "string"
+                      },
+                      "pattern": {
+                        "description": "Pattern specifies an overlay-style pattern used to check resources.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "podSecurity": {
+                        "description": "PodSecurity applies exemptions for Kubernetes Pod Security admission\nby specifying exclusions for Pod Security Standards controls.",
+                        "properties": {
+                          "exclude": {
+                            "description": "Exclude specifies the Pod Security Standard controls to be excluded.",
+                            "items": {
+                              "description": "PodSecurityStandard specifies the Pod Security Standard controls to be excluded.",
+                              "properties": {
+                                "controlName": {
+                                  "description": "ControlName specifies the name of the Pod Security Standard control.\nSee: https://kubernetes.io/docs/concepts/security/pod-security-standards/",
+                                  "enum": [
+                                    "HostProcess",
+                                    "Host Namespaces",
+                                    "Privileged Containers",
+                                    "Capabilities",
+                                    "HostPath Volumes",
+                                    "Host Ports",
+                                    "AppArmor",
+                                    "SELinux",
+                                    "/proc Mount Type",
+                                    "Seccomp",
+                                    "Sysctls",
+                                    "Volume Types",
+                                    "Privilege Escalation",
+                                    "Running as Non-root",
+                                    "Running as Non-root user"
+                                  ],
+                                  "type": "string"
+                                },
+                                "images": {
+                                  "description": "Images selects matching containers and applies the container level PSS.\nEach image is the image name consisting of the registry address, repository, image, and tag.\nEmpty list matches no containers, PSS checks are applied at the pod level only.\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "restrictedField": {
+                                  "description": "RestrictedField selects the field for the given Pod Security Standard control.\nWhen not set, all restricted fields for the control are selected.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "Values defines the allowed values that can be excluded.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "controlName"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          },
+                          "level": {
+                            "description": "Level defines the Pod Security Standard level to be applied to workloads.\nAllowed values are privileged, baseline, and restricted.",
+                            "enum": [
+                              "privileged",
+                              "baseline",
+                              "restricted"
+                            ],
+                            "type": "string"
+                          },
+                          "version": {
+                            "description": "Version defines the Pod Security Standard versions that Kubernetes supports.\nAllowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, v1.27, v1.28, v1.29, v1.30, v1.31, v1.32, latest. Defaults to latest.",
+                            "enum": [
+                              "v1.19",
+                              "v1.20",
+                              "v1.21",
+                              "v1.22",
+                              "v1.23",
+                              "v1.24",
+                              "v1.25",
+                              "v1.26",
+                              "v1.27",
+                              "v1.28",
+                              "v1.29",
+                              "v1.30",
+                              "v1.31",
+                              "v1.32",
+                              "latest"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "verifyImages": {
+                    "description": "VerifyImages is used to verify image signatures and mutate them to add a digest",
+                    "items": {
+                      "description": "ImageVerification validates that images that match the specified pattern\nare signed with the supplied public key. Once the image is verified it is\nmutated to include the SHA digest retrieved during the registration.",
+                      "properties": {
+                        "additionalExtensions": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Deprecated.",
+                          "type": "object"
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Deprecated. Use annotations per Attestor instead.",
+                          "type": "object"
+                        },
+                        "attestations": {
+                          "description": "Attestations are optional checks for signed in-toto Statements used to verify the image.\nSee https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the\nOCI registry and decodes them into a list of Statement declarations.",
+                          "items": {
+                            "description": "Attestation are checks for signed in-toto Statements that are used to verify the image.\nSee https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the\nOCI registry and decodes them into a list of Statements.",
+                            "properties": {
+                              "attestors": {
+                                "description": "Attestors specify the required attestors (i.e. authorities).",
+                                "items": {
+                                  "properties": {
+                                    "count": {
+                                      "description": "Count specifies the required number of entries that must match. If the count is null, all entries must match\n(a logical AND). If the count is 1, at least one entry must match (a logical OR). If the count contains a\nvalue N, then N must be less than or equal to the size of entries, and at least N entries must match.",
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    },
+                                    "entries": {
+                                      "description": "Entries contains the available attestors. An attestor can be a static key,\nattributes for keyless verification, or a nested attestor declaration.",
+                                      "items": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "Annotations are used for image verification.\nEvery specified key-value pair must exist and match in the verified payload.\nThe payload may contain other key-value pairs.",
+                                            "type": "object"
+                                          },
+                                          "attestor": {
+                                            "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          },
+                                          "certificates": {
+                                            "description": "Certificates specifies one or more certificates.",
+                                            "properties": {
+                                              "cert": {
+                                                "description": "Cert is an optional PEM-encoded public certificate.",
+                                                "type": "string"
+                                              },
+                                              "certChain": {
+                                                "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
+                                                "type": "string"
+                                              },
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "rekor": {
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
+                                                  "url": {
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "keyless": {
+                                            "description": "Keyless is a set of attribute used to verify a Sigstore keyless attestor.\nSee https://github.com/sigstore/cosign/blob/main/KEYLESS.md.",
+                                            "properties": {
+                                              "additionalExtensions": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
+                                                "type": "object"
+                                              },
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "issuer": {
+                                                "description": "Issuer is the certificate issuer used for keyless signing.",
+                                                "type": "string"
+                                              },
+                                              "issuerRegExp": {
+                                                "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
+                                                "type": "string"
+                                              },
+                                              "rekor": {
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
+                                                  "url": {
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "roots": {
+                                                "description": "Roots is an optional set of PEM encoded trusted root certificates.\nIf not provided, the system roots are used.",
+                                                "type": "string"
+                                              },
+                                              "subject": {
+                                                "description": "Subject is the verified identity used for keyless signing, for example the email address.",
+                                                "type": "string"
+                                              },
+                                              "subjectRegExp": {
+                                                "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "keys": {
+                                            "description": "Keys specifies one or more public keys.",
+                                            "properties": {
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  },
+                                                  "tsaCertChain": {
+                                                    "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "kms": {
+                                                "description": "KMS provides the URI to the public key stored in a Key Management System. See:\nhttps://github.com/sigstore/cosign/blob/main/KMS.md",
+                                                "type": "string"
+                                              },
+                                              "publicKeys": {
+                                                "description": "Keys is a set of X.509 public keys used to verify image signatures. The keys can be directly\nspecified or can be a variable reference to a key specified in a ConfigMap (see\nhttps://kyverno.io/docs/writing-policies/variables/), or reference a standard Kubernetes Secret\nelsewhere in the cluster by specifying it in the format \"k8s://<namespace>/<secret_name>\".\nThe named Secret must specify a key `cosign.pub` containing the public key used for\nverification, (see https://github.com/sigstore/cosign/blob/main/KMS.md#kubernetes-secret).\nWhen multiple keys are specified each key is processed as a separate staticKey entry\n(.attestors[*].entries.keys) within the set of attestors and the count is applied across the keys.",
+                                                "type": "string"
+                                              },
+                                              "rekor": {
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
+                                                  "url": {
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "secret": {
+                                                "description": "Reference to a Secret resource that contains a public key",
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "Name of the secret. The provided secret must contain a key named cosign.pub.",
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "description": "Namespace name where the Secret exists.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "namespace"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              "signatureAlgorithm": {
+                                                "default": "sha256",
+                                                "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "repository": {
+                                            "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                            "type": "string"
+                                          },
+                                          "signatureAlgorithm": {
+                                            "default": "sha256",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "conditions": {
+                                "description": "Conditions are used to verify attributes within a Predicate. If no Conditions are specified\nthe attestation check is satisfied as long there are predicates that match the predicate type.",
+                                "items": {
+                                  "description": "AnyAllConditions consists of conditions wrapped denoting a logical criteria to be fulfilled.\nAnyConditions get fulfilled when at least one of its sub-conditions passes.\nAllConditions get fulfilled only when all of its sub-conditions pass.",
+                                  "properties": {
+                                    "all": {
+                                      "description": "AllConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, all of the conditions need to pass",
+                                      "items": {
+                                        "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          },
+                                          "message": {
+                                            "description": "Message is an optional display message",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                            "enum": [
+                                              "Equals",
+                                              "NotEquals",
+                                              "In",
+                                              "AnyIn",
+                                              "AllIn",
+                                              "NotIn",
+                                              "AnyNotIn",
+                                              "AllNotIn",
+                                              "GreaterThanOrEquals",
+                                              "GreaterThan",
+                                              "LessThanOrEquals",
+                                              "LessThan",
+                                              "DurationGreaterThanOrEquals",
+                                              "DurationGreaterThan",
+                                              "DurationLessThanOrEquals",
+                                              "DurationLessThan"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "any": {
+                                      "description": "AnyConditions enable variable-based conditional rule execution. This is useful for\nfiner control of when an rule is applied. A condition can reference object data\nusing JMESPath notation.\nHere, at least one of the conditions need to pass",
+                                      "items": {
+                                        "description": "Condition defines variable-based conditional criteria for rule execution.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          },
+                                          "message": {
+                                            "description": "Message is an optional display message",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "Operator is the conditional operation to perform. Valid operators are:\nEquals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals,\nGreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan,\nDurationLessThanOrEquals, DurationLessThan",
+                                            "enum": [
+                                              "Equals",
+                                              "NotEquals",
+                                              "In",
+                                              "AnyIn",
+                                              "AllIn",
+                                              "NotIn",
+                                              "AnyNotIn",
+                                              "AllNotIn",
+                                              "GreaterThanOrEquals",
+                                              "GreaterThan",
+                                              "LessThanOrEquals",
+                                              "LessThan",
+                                              "DurationGreaterThanOrEquals",
+                                              "DurationGreaterThan",
+                                              "DurationLessThanOrEquals",
+                                              "DurationLessThan"
+                                            ],
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "Value is the conditional value, or set of values. The values can be fixed set\nor can be variables declared using JMESPath.",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "predicateType": {
+                                "description": "Deprecated in favour of 'Type', to be removed soon",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type defines the type of attestation contained within the Statement.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "attestors": {
+                          "description": "Attestors specified the required attestors (i.e. authorities)",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "description": "Count specifies the required number of entries that must match. If the count is null, all entries must match\n(a logical AND). If the count is 1, at least one entry must match (a logical OR). If the count contains a\nvalue N, then N must be less than or equal to the size of entries, and at least N entries must match.",
+                                "minimum": 1,
+                                "type": "integer"
+                              },
+                              "entries": {
+                                "description": "Entries contains the available attestors. An attestor can be a static key,\nattributes for keyless verification, or a nested attestor declaration.",
+                                "items": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "Annotations are used for image verification.\nEvery specified key-value pair must exist and match in the verified payload.\nThe payload may contain other key-value pairs.",
+                                      "type": "object"
+                                    },
+                                    "attestor": {
+                                      "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
+                                    "certificates": {
+                                      "description": "Certificates specifies one or more certificates.",
+                                      "properties": {
+                                        "cert": {
+                                          "description": "Cert is an optional PEM-encoded public certificate.",
+                                          "type": "string"
+                                        },
+                                        "certChain": {
+                                          "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
+                                          "type": "string"
+                                        },
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "rekor": {
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "keyless": {
+                                      "description": "Keyless is a set of attribute used to verify a Sigstore keyless attestor.\nSee https://github.com/sigstore/cosign/blob/main/KEYLESS.md.",
+                                      "properties": {
+                                        "additionalExtensions": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
+                                          "type": "object"
+                                        },
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "issuer": {
+                                          "description": "Issuer is the certificate issuer used for keyless signing.",
+                                          "type": "string"
+                                        },
+                                        "issuerRegExp": {
+                                          "description": "IssuerRegExp is the regular expression to match certificate issuer used for keyless signing.",
+                                          "type": "string"
+                                        },
+                                        "rekor": {
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "roots": {
+                                          "description": "Roots is an optional set of PEM encoded trusted root certificates.\nIf not provided, the system roots are used.",
+                                          "type": "string"
+                                        },
+                                        "subject": {
+                                          "description": "Subject is the verified identity used for keyless signing, for example the email address.",
+                                          "type": "string"
+                                        },
+                                        "subjectRegExp": {
+                                          "description": "SubjectRegExp is the regular expression to match identity used for keyless signing, for example the email address.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "keys": {
+                                      "description": "Keys specifies one or more public keys.",
+                                      "properties": {
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate\nTimestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate\ntimestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            },
+                                            "tsaCertChain": {
+                                              "description": "TSACertChain, if set, is the PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must\ncontain the root CA certificate. Optionally may contain intermediate CA certificates, and\nmay contain the leaf TSA certificate if not present in the timestamurce.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "kms": {
+                                          "description": "KMS provides the URI to the public key stored in a Key Management System. See:\nhttps://github.com/sigstore/cosign/blob/main/KMS.md",
+                                          "type": "string"
+                                        },
+                                        "publicKeys": {
+                                          "description": "Keys is a set of X.509 public keys used to verify image signatures. The keys can be directly\nspecified or can be a variable reference to a key specified in a ConfigMap (see\nhttps://kyverno.io/docs/writing-policies/variables/), or reference a standard Kubernetes Secret\nelsewhere in the cluster by specifying it in the format \"k8s://<namespace>/<secret_name>\".\nThe named Secret must specify a key `cosign.pub` containing the public key used for\nverification, (see https://github.com/sigstore/cosign/blob/main/KMS.md#kubernetes-secret).\nWhen multiple keys are specified each key is processed as a separate staticKey entry\n(.attestors[*].entries.keys) within the set of attestors and the count is applied across the keys.",
+                                          "type": "string"
+                                        },
+                                        "rekor": {
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object\nis provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor.\nIf set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "secret": {
+                                          "description": "Reference to a Secret resource that contains a public key",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the secret. The provided secret must contain a key named cosign.pub.",
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "description": "Namespace name where the Secret exists.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "namespace"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "signatureAlgorithm": {
+                                          "default": "sha256",
+                                          "description": "Deprecated. Use attestor.signatureAlgorithm instead.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "repository": {
+                                      "description": "Repository is an optional alternate OCI repository to use for signatures and attestations that match this rule.\nIf specified Repository will override other OCI image repository locations for this Attestor.",
+                                      "type": "string"
+                                    },
+                                    "signatureAlgorithm": {
+                                      "default": "sha256",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha224, sha256, sha384 and sha512.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "cosignOCI11": {
+                          "description": "CosignOCI11 enables the experimental OCI 1.1 behaviour in cosign image verification.\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "failureAction": {
+                          "description": "Allowed values are Audit or Enforce.",
+                          "enum": [
+                            "Audit",
+                            "Enforce"
+                          ],
+                          "type": "string"
+                        },
+                        "image": {
+                          "description": "Deprecated. Use ImageReferences instead.",
+                          "type": "string"
+                        },
+                        "imageReferences": {
+                          "description": "ImageReferences is a list of matching image reference patterns. At least one pattern in the\nlist must match the image for the rule to apply. Each image reference consists of a registry\naddress (defaults to docker.io), repository, image, and tag (defaults to latest).\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry.",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided.\nIt can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "issuer": {
+                          "description": "Deprecated. Use KeylessAttestor instead.",
+                          "type": "string"
+                        },
+                        "key": {
+                          "description": "Deprecated. Use StaticKeyAttestor instead.",
+                          "type": "string"
+                        },
+                        "mutateDigest": {
+                          "default": true,
+                          "description": "MutateDigest enables replacement of image tags with digests.\nDefaults to true.",
+                          "type": "boolean"
+                        },
+                        "repository": {
+                          "description": "Repository is an optional alternate OCI repository to use for image signatures and attestations that match this rule.\nIf specified Repository will override the default OCI image repository configured for the installation.\nThe repository can also be overridden per Attestor or Attestation.",
+                          "type": "string"
+                        },
+                        "required": {
+                          "default": true,
+                          "description": "Required validates that images are verified i.e. have matched passed a signature or attestation check.",
+                          "type": "boolean"
+                        },
+                        "roots": {
+                          "description": "Deprecated. Use KeylessAttestor instead.",
+                          "type": "string"
+                        },
+                        "skipImageReferences": {
+                          "description": "SkipImageReferences is a list of matching image reference patterns that should be skipped.\nAt least one pattern in the list must match the image for the rule to be skipped. Each image reference\nconsists of a registry address (defaults to docker.io), repository, image, and tag (defaults to latest).\nWildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "subject": {
+                          "description": "Deprecated. Use KeylessAttestor instead.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Type specifies the method of signature validation. The allowed options\nare Cosign, Sigstore Bundle and Notary. By default Cosign is used if a type is not specified.",
+                          "enum": [
+                            "Cosign",
+                            "SigstoreBundle",
+                            "Notary"
+                          ],
+                          "type": "string"
+                        },
+                        "useCache": {
+                          "default": true,
+                          "description": "UseCache enables caching of image verify responses for this rule.",
+                          "type": "boolean"
+                        },
+                        "validate": {
+                          "description": "Validation checks conditions across multiple image\nverification attestations or context entries",
+                          "properties": {
+                            "deny": {
+                              "description": "Deny defines conditions used to pass or fail a validation rule.",
+                              "properties": {
+                                "conditions": {
+                                  "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list\nof conditions (without `any` or `all` statements) is also supported for backwards compatibility\nbut will be deprecated in the next major release.\nSee: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "message": {
+                              "description": "Message specifies a custom message to be displayed on failure.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "verifyDigest": {
+                          "default": true,
+                          "description": "VerifyDigest validates that images have a digest.",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "match",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "ready": {
+          "description": "Deprecated in favor of Conditions",
+          "type": "boolean"
+        },
+        "rulecount": {
+          "description": "RuleCountStatus contains four variables which describes counts for\nvalidate, generate, mutate and verify images rules",
+          "properties": {
+            "generate": {
+              "description": "Count for generate rules in policy",
+              "type": "integer"
+            },
+            "mutate": {
+              "description": "Count for mutate rules in policy",
+              "type": "integer"
+            },
+            "validate": {
+              "description": "Count for validate rules in policy",
+              "type": "integer"
+            },
+            "verifyimages": {
+              "description": "Count for verify image rules in policy",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "generate",
+            "mutate",
+            "validate",
+            "verifyimages"
+          ],
+          "type": "object"
+        },
+        "validatingadmissionpolicy": {
+          "description": "ValidatingAdmissionPolicy contains status information",
+          "properties": {
+            "generated": {
+              "description": "Generated indicates whether a validating admission policy is generated from the policy or not",
+              "type": "boolean"
+            },
+            "message": {
+              "description": "Message is a human readable message indicating details about the generation of validating admission policy\nIt is an empty string when validating admission policy is successfully generated.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "generated",
+            "message"
+          ],
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

- Improves documentation schema validation to eliminate all unrecognized snippet warnings
- Adds Kyverno ClusterPolicy schema for external CRD validation
- Fixes documentation snippets to be properly detectable

## Changes

### Documentation Fixes
- `docs/operations/secret-rotation.md`: Added `apiVersion: apps/v1` to Deployment snippet
- `docs/guides/observability.md`: Wrapped tracing snippet with full CR context, marked plain-text blocks with `text` language hint

### Validation Infrastructure
- Added `Deployment`, `StatefulSet`, `DaemonSet` to `k8s_core_kinds` for K8s core resource detection
- Added Kyverno ClusterPolicy schema (`scripts/schemas/external/kyverno-clusterpolicy.schema.json`)
- Added external CRD validation support for Kyverno policies
- Added detection for `config` and `mappers` partial snippets
- Added `partial:idp-config` and `partial:federation-mappers` to known skip reasons

## Results

| Metric | Before | After |
|--------|--------|-------|
| Unrecognized snippets | 7 ⚠️ | 0 ✅ |
| Skipped (known) | 22 | 17 |
| Validated & passed | 259 | 262 |