### PR TITLE
ci: fix integration test coverage retrieval

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -457,6 +457,12 @@ tasks:
         fi
 
         if [ "{{default "false" .COVERAGE}}" = "true" ]; then
+          echo "Retrieving coverage data..."
+          if ! bash scripts/retrieve-coverage.sh; then
+            echo "❌ Failed to retrieve coverage data via scripts/retrieve-coverage.sh"
+            exit 1
+          fi
+
           echo "Combining coverage data..."
           if ! bash scripts/combine-coverage.sh; then
             echo "❌ Failed to combine coverage data via scripts/combine-coverage.sh"


### PR DESCRIPTION
## Summary
The reported coverage had declined because integration test coverage was not being collected before combination.

This PR ensures `scripts/retrieve-coverage.sh` is called in `Taskfile.yml` before `scripts/combine-coverage.sh` when `COVERAGE=true`.

This fixes the issue where only unit test coverage was being reported to Codecov.

## Changes
- Updated `Taskfile.yml` to retrieve coverage data from the operator pod after integration tests complete.