### PR TITLE
feat(chart-operator+chart-realm+operator): add browser security headers support

### DIFF
--- a/charts/keycloak-operator/crds/keycloakrealm-crd.yaml
+++ b/charts/keycloak-operator/crds/keycloakrealm-crd.yaml
@@ -114,6 +114,34 @@ spec:
                   failureFactor:
                     type: integer
                     minimum: 1
+              browserSecurityHeaders:
+                type: object
+                description: Browser security headers configuration
+                properties:
+                  contentSecurityPolicy:
+                    type: string
+                    description: Content Security Policy header
+                  contentSecurityPolicyReportOnly:
+                    type: string
+                    description: Content Security Policy Report Only header
+                  xContentTypeOptions:
+                    type: string
+                    description: X-Content-Type-Options header
+                  xFrameOptions:
+                    type: string
+                    description: X-Frame-Options header
+                  xRobotsTag:
+                    type: string
+                    description: X-Robots-Tag header
+                  xXSSProtection:
+                    type: string
+                    description: X-XSS-Protection header
+                  strictTransportSecurity:
+                    type: string
+                    description: Strict-Transport-Security header
+                  referrerPolicy:
+                    type: string
+                    description: Referrer-Policy header
               tokenSettings:
                 type: object
                 description: Token and session configuration

--- a/charts/keycloak-realm/README.md
+++ b/charts/keycloak-realm/README.md
@@ -169,6 +169,21 @@ kubectl describe keycloakrealm my-realm -n my-team
 | `security.maxDeltaTime` | Max time window for failures (seconds) | `43200` (12 hours) |
 | `security.failureFactor` | Number of failures before lockout | `30` |
 
+#### Browser Security Headers
+
+Configure HTTP security headers served on Keycloak login pages (CSP, X-Frame-Options, etc.).
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `browserSecurityHeaders.contentSecurityPolicy` | Content Security Policy | `frame-src 'self'; ...` |
+| `browserSecurityHeaders.contentSecurityPolicyReportOnly` | CSP Report Only mode | `""` |
+| `browserSecurityHeaders.xContentTypeOptions` | X-Content-Type-Options | `nosniff` |
+| `browserSecurityHeaders.xFrameOptions` | X-Frame-Options | `SAMEORIGIN` |
+| `browserSecurityHeaders.xRobotsTag` | X-Robots-Tag | `none` |
+| `browserSecurityHeaders.xXSSProtection` | X-XSS-Protection | `1; mode=block` |
+| `browserSecurityHeaders.strictTransportSecurity` | Strict-Transport-Security | `max-age=31536000; ...` |
+| `browserSecurityHeaders.referrerPolicy` | Referrer-Policy | `no-referrer` |
+
 #### Theme Configuration
 
 | Parameter | Description | Default |

--- a/charts/keycloak-realm/templates/realm.yaml
+++ b/charts/keycloak-realm/templates/realm.yaml
@@ -40,6 +40,11 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
+  {{- with .Values.browserSecurityHeaders }}
+  browserSecurityHeaders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   {{- if or .Values.themes.login .Values.themes.admin .Values.themes.account .Values.themes.email }}
   themes:
     {{- with .Values.themes.login }}

--- a/charts/keycloak-realm/values.schema.json
+++ b/charts/keycloak-realm/values.schema.json
@@ -48,6 +48,19 @@
         "failureFactor": {"type": "integer"}
       }
     },
+    "browserSecurityHeaders": {
+      "type": "object",
+      "properties": {
+        "contentSecurityPolicy": {"type": "string"},
+        "contentSecurityPolicyReportOnly": {"type": "string"},
+        "xContentTypeOptions": {"type": "string"},
+        "xFrameOptions": {"type": "string"},
+        "xRobotsTag": {"type": "string"},
+        "xXSSProtection": {"type": "string"},
+        "strictTransportSecurity": {"type": "string"},
+        "referrerPolicy": {"type": "string"}
+      }
+    },
     "themes": {
       "type": "object",
       "properties": {

--- a/charts/keycloak-realm/values.yaml
+++ b/charts/keycloak-realm/values.yaml
@@ -63,6 +63,26 @@ security:
   maxDeltaTime: 43200
   failureFactor: 30
 
+# Browser Security Headers (optional)
+# Configure security headers served on Keycloak login pages
+browserSecurityHeaders:
+  # Content Security Policy (default: frame-src 'self'; frame-ancestors 'self'; object-src 'none';)
+  contentSecurityPolicy: "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
+  # CSP Report Only (optional)
+  # contentSecurityPolicyReportOnly: ""
+  # X-Content-Type-Options (default: nosniff)
+  xContentTypeOptions: "nosniff"
+  # X-Frame-Options (default: SAMEORIGIN)
+  xFrameOptions: "SAMEORIGIN"
+  # X-Robots-Tag (default: none)
+  xRobotsTag: "none"
+  # X-XSS-Protection (default: 1; mode=block)
+  xXSSProtection: "1; mode=block"
+  # Strict-Transport-Security (default: max-age=31536000; includeSubDomains)
+  strictTransportSecurity: "max-age=31536000; includeSubDomains"
+  # Referrer-Policy (default: no-referrer)
+  referrerPolicy: "no-referrer"
+
 # Theme configuration
 themes:
   login: ""

--- a/tests/integration/test_realm_security_headers.py
+++ b/tests/integration/test_realm_security_headers.py
@@ -1,0 +1,198 @@
+"""
+Integration tests for Realm security headers.
+
+Tests verify that browser security headers are correctly configured in Keycloak.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+
+import pytest
+from kubernetes.client.rest import ApiException
+
+from .wait_helpers import wait_for_resource_ready
+
+
+@pytest.mark.integration
+@pytest.mark.requires_cluster
+class TestRealmSecurityHeaders:
+    """Test Realm security headers functionality."""
+
+    @pytest.mark.timeout(300)
+    async def test_realm_security_headers(
+        self,
+        k8s_custom_objects,
+        test_namespace,
+        operator_namespace,
+        shared_operator,
+        keycloak_admin_client,
+    ) -> None:
+        """Test configuring browser security headers."""
+        suffix = uuid.uuid4().hex[:8]
+        realm_name = f"test-headers-{suffix}"
+        namespace = test_namespace
+
+        from keycloak_operator.models.realm import (
+            KeycloakBrowserSecurityHeaders,
+            KeycloakRealmSpec,
+            OperatorRef,
+        )
+
+        headers = KeycloakBrowserSecurityHeaders(
+            contentSecurityPolicy="frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+            xFrameOptions="SAMEORIGIN",
+            xContentTypeOptions="nosniff",
+            xRobotsTag="none",
+            xXSSProtection="1; mode=block",
+            strictTransportSecurity="max-age=31536000; includeSubDomains",
+            referrerPolicy="no-referrer",
+        )
+
+        realm_spec = KeycloakRealmSpec(
+            operator_ref=OperatorRef(namespace=operator_namespace),
+            realm_name=realm_name,
+            display_name="Test Security Headers Realm",
+            client_authorization_grants=[namespace],
+            browserSecurityHeaders=headers,
+        )
+
+        realm_manifest = {
+            "apiVersion": "vriesdemichael.github.io/v1",
+            "kind": "KeycloakRealm",
+            "metadata": {"name": realm_name, "namespace": namespace},
+            "spec": realm_spec.model_dump(by_alias=True, exclude_unset=True),
+        }
+
+        try:
+            # CREATE: Deploy realm
+            await k8s_custom_objects.create_namespaced_custom_object(
+                group="vriesdemichael.github.io",
+                version="v1",
+                namespace=namespace,
+                plural="keycloakrealms",
+                body=realm_manifest,
+            )
+
+            # READY: Wait for realm to become ready
+            await wait_for_resource_ready(
+                k8s_custom_objects=k8s_custom_objects,
+                group="vriesdemichael.github.io",
+                version="v1",
+                namespace=namespace,
+                plural="keycloakrealms",
+                name=realm_name,
+                timeout=150,
+                operator_namespace=operator_namespace,
+            )
+
+            # VERIFY: Check headers in Keycloak
+            realm_repr = await keycloak_admin_client.get_realm(realm_name, namespace)
+            assert realm_repr is not None
+
+            # The Keycloak API returns browserSecurityHeaders as a dict
+            security_headers = realm_repr.browser_security_headers
+            assert security_headers is not None
+            assert (
+                security_headers["contentSecurityPolicy"]
+                == "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
+            )
+            assert security_headers["xFrameOptions"] == "SAMEORIGIN"
+            assert security_headers["xContentTypeOptions"] == "nosniff"
+            assert security_headers["xRobotsTag"] == "none"
+            assert security_headers["xXSSProtection"] == "1; mode=block"
+            assert (
+                security_headers["strictTransportSecurity"]
+                == "max-age=31536000; includeSubDomains"
+            )
+            assert security_headers["referrerPolicy"] == "no-referrer"
+
+            # UPDATE: Change headers
+            for attempt in range(5):
+                try:
+                    realm_cr = await k8s_custom_objects.get_namespaced_custom_object(
+                        group="vriesdemichael.github.io",
+                        version="v1",
+                        namespace=namespace,
+                        plural="keycloakrealms",
+                        name=realm_name,
+                    )
+
+                    current_spec = KeycloakRealmSpec.model_validate(realm_cr["spec"])
+                    # Update X-Frame-Options to DENY
+                    if current_spec.browser_security_headers:
+                        current_spec.browser_security_headers.x_frame_options = "DENY"
+                        # Add Report Only CSP
+                        current_spec.browser_security_headers.content_security_policy_report_only = "default-src 'none';"
+                    else:
+                        # Should not happen given setup, but for type safety
+                        current_spec.browser_security_headers = (
+                            KeycloakBrowserSecurityHeaders(
+                                xFrameOptions="DENY",
+                                contentSecurityPolicyReportOnly="default-src 'none';",
+                            )
+                        )
+
+                    realm_cr["spec"] = current_spec.model_dump(
+                        by_alias=True, exclude_unset=True
+                    )
+
+                    await k8s_custom_objects.patch_namespaced_custom_object(
+                        group="vriesdemichael.github.io",
+                        version="v1",
+                        namespace=namespace,
+                        plural="keycloakrealms",
+                        name=realm_name,
+                        body=realm_cr,
+                    )
+                    break
+                except ApiException as e:
+                    if e.status == 409 and attempt < 4:
+                        await asyncio.sleep(0.5)
+                        continue
+                    raise
+
+            # Wait for reconciliation
+            await wait_for_resource_ready(
+                k8s_custom_objects,
+                group="vriesdemichael.github.io",
+                version="v1",
+                namespace=namespace,
+                plural="keycloakrealms",
+                name=realm_name,
+                timeout=60,
+                operator_namespace=operator_namespace,
+            )
+
+            # Wait for update in Keycloak
+            max_attempts = 10
+            for attempt in range(max_attempts):
+                realm_repr = await keycloak_admin_client.get_realm(
+                    realm_name, namespace
+                )
+                headers = realm_repr.browser_security_headers
+                if headers and headers.get("xFrameOptions") == "DENY":
+                    break
+                if attempt < max_attempts - 1:
+                    await asyncio.sleep(1)
+
+            # VERIFY updates
+            realm_repr = await keycloak_admin_client.get_realm(realm_name, namespace)
+            security_headers = realm_repr.browser_security_headers
+            assert security_headers["xFrameOptions"] == "DENY"
+            assert (
+                security_headers["contentSecurityPolicyReportOnly"]
+                == "default-src 'none';"
+            )
+
+        finally:
+            with contextlib.suppress(ApiException):
+                await k8s_custom_objects.delete_namespaced_custom_object(
+                    group="vriesdemichael.github.io",
+                    version="v1",
+                    namespace=namespace,
+                    plural="keycloakrealms",
+                    name=realm_name,
+                )

--- a/tests/unit/models/test_realm_security_headers.py
+++ b/tests/unit/models/test_realm_security_headers.py
@@ -1,0 +1,52 @@
+from keycloak_operator.models.realm import (
+    KeycloakBrowserSecurityHeaders,
+    KeycloakRealmSpec,
+)
+
+
+def test_browser_security_headers_defaults():
+    """Test default values for browser security headers."""
+    headers = KeycloakBrowserSecurityHeaders()
+    assert (
+        headers.content_security_policy
+        == "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
+    )
+    assert headers.x_content_type_options == "nosniff"
+    assert headers.x_frame_options == "SAMEORIGIN"
+    assert headers.x_robots_tag == "none"
+    assert headers.x_xss_protection == "1; mode=block"
+    assert headers.strict_transport_security == "max-age=31536000; includeSubDomains"
+    assert headers.referrer_policy == "no-referrer"
+    assert headers.content_security_policy_report_only is None
+
+
+def test_realm_spec_with_security_headers():
+    """Test realm spec serialization with security headers."""
+    headers = KeycloakBrowserSecurityHeaders(
+        contentSecurityPolicy="default-src 'self';", xFrameOptions="DENY"
+    )
+    spec = KeycloakRealmSpec(
+        realmName="test-realm",
+        operatorRef={"namespace": "test-ns"},
+        browserSecurityHeaders=headers,
+    )
+
+    config = spec.to_keycloak_config(include_flow_bindings=False)
+    assert "browserSecurityHeaders" in config
+    assert (
+        config["browserSecurityHeaders"]["contentSecurityPolicy"]
+        == "default-src 'self';"
+    )
+    assert config["browserSecurityHeaders"]["xFrameOptions"] == "DENY"
+    # Defaults should be preserved if not overridden
+    assert config["browserSecurityHeaders"]["xContentTypeOptions"] == "nosniff"
+
+
+def test_realm_spec_without_security_headers():
+    """Test realm spec serialization without security headers."""
+    spec = KeycloakRealmSpec(
+        realmName="test-realm", operatorRef={"namespace": "test-ns"}
+    )
+
+    config = spec.to_keycloak_config(include_flow_bindings=False)
+    assert "browserSecurityHeaders" not in config


### PR DESCRIPTION
## Summary
Added support for configuring browser security headers in Keycloak Realms.

- **Operator**: Added `KeycloakBrowserSecurityHeaders` model and field to `KeycloakRealmSpec`.
- **CRD**: Updated `KeycloakRealm` CRD to include `browserSecurityHeaders`.
- **Helm**: Updated `keycloak-realm` chart to support `browserSecurityHeaders` configuration.
- **Tests**: Added unit and integration tests verifying headers are correctly set in Keycloak.

Closes #534