### PR TITLE
fix(chart-realm+operator): correct defaults for browser security headers

### DIFF
--- a/charts/keycloak-realm/templates/realm.yaml
+++ b/charts/keycloak-realm/templates/realm.yaml
@@ -41,8 +41,33 @@ spec:
   {{- end }}
 
   {{- with .Values.browserSecurityHeaders }}
+  {{- if or .contentSecurityPolicy .contentSecurityPolicyReportOnly .xContentTypeOptions .xFrameOptions .xRobotsTag .xXSSProtection .strictTransportSecurity .referrerPolicy }}
   browserSecurityHeaders:
-    {{- toYaml . | nindent 4 }}
+    {{- with .contentSecurityPolicy }}
+    contentSecurityPolicy: {{ . | quote }}
+    {{- end }}
+    {{- with .contentSecurityPolicyReportOnly }}
+    contentSecurityPolicyReportOnly: {{ . | quote }}
+    {{- end }}
+    {{- with .xContentTypeOptions }}
+    xContentTypeOptions: {{ . | quote }}
+    {{- end }}
+    {{- with .xFrameOptions }}
+    xFrameOptions: {{ . | quote }}
+    {{- end }}
+    {{- with .xRobotsTag }}
+    xRobotsTag: {{ . | quote }}
+    {{- end }}
+    {{- with .xXSSProtection }}
+    xXSSProtection: {{ . | quote }}
+    {{- end }}
+    {{- with .strictTransportSecurity }}
+    strictTransportSecurity: {{ . | quote }}
+    {{- end }}
+    {{- with .referrerPolicy }}
+    referrerPolicy: {{ . | quote }}
+    {{- end }}
+  {{- end }}
   {{- end }}
 
   {{- if or .Values.themes.login .Values.themes.admin .Values.themes.account .Values.themes.email }}

--- a/charts/keycloak-realm/values.yaml
+++ b/charts/keycloak-realm/values.yaml
@@ -65,23 +65,24 @@ security:
 
 # Browser Security Headers (optional)
 # Configure security headers served on Keycloak login pages
+# Leave values empty to let Keycloak use its built-in defaults.
 browserSecurityHeaders:
-  # Content Security Policy (default: frame-src 'self'; frame-ancestors 'self'; object-src 'none';)
-  contentSecurityPolicy: "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
+  # Content Security Policy (Keycloak default: frame-src 'self'; frame-ancestors 'self'; object-src 'none';)
+  contentSecurityPolicy: ""
   # CSP Report Only (optional)
-  # contentSecurityPolicyReportOnly: ""
-  # X-Content-Type-Options (default: nosniff)
-  xContentTypeOptions: "nosniff"
-  # X-Frame-Options (default: SAMEORIGIN)
-  xFrameOptions: "SAMEORIGIN"
-  # X-Robots-Tag (default: none)
-  xRobotsTag: "none"
-  # X-XSS-Protection (default: 1; mode=block)
-  xXSSProtection: "1; mode=block"
-  # Strict-Transport-Security (default: max-age=31536000; includeSubDomains)
-  strictTransportSecurity: "max-age=31536000; includeSubDomains"
-  # Referrer-Policy (default: no-referrer)
-  referrerPolicy: "no-referrer"
+  contentSecurityPolicyReportOnly: ""
+  # X-Content-Type-Options (Keycloak default: nosniff)
+  xContentTypeOptions: ""
+  # X-Frame-Options (Keycloak default: SAMEORIGIN)
+  xFrameOptions: ""
+  # X-Robots-Tag (Keycloak default: none)
+  xRobotsTag: ""
+  # X-XSS-Protection (Keycloak default: 1; mode=block)
+  xXSSProtection: ""
+  # Strict-Transport-Security (Keycloak default: max-age=31536000; includeSubDomains)
+  strictTransportSecurity: ""
+  # Referrer-Policy (Keycloak default: no-referrer)
+  referrerPolicy: ""
 
 # Theme configuration
 themes:

--- a/src/keycloak_operator/models/realm.py
+++ b/src/keycloak_operator/models/realm.py
@@ -989,8 +989,8 @@ class KeycloakBrowserSecurityHeaders(BaseModel):
 
     model_config = {"populate_by_name": True}
 
-    content_security_policy: str = Field(
-        "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    content_security_policy: str | None = Field(
+        None,
         alias="contentSecurityPolicy",
         description="Content Security Policy header",
     )
@@ -999,33 +999,33 @@ class KeycloakBrowserSecurityHeaders(BaseModel):
         alias="contentSecurityPolicyReportOnly",
         description="Content Security Policy Report Only header",
     )
-    x_content_type_options: str = Field(
-        "nosniff",
+    x_content_type_options: str | None = Field(
+        None,
         alias="xContentTypeOptions",
         description="X-Content-Type-Options header",
     )
-    x_frame_options: str = Field(
-        "SAMEORIGIN",
+    x_frame_options: str | None = Field(
+        None,
         alias="xFrameOptions",
         description="X-Frame-Options header",
     )
-    x_robots_tag: str = Field(
-        "none",
+    x_robots_tag: str | None = Field(
+        None,
         alias="xRobotsTag",
         description="X-Robots-Tag header",
     )
-    x_xss_protection: str = Field(
-        "1; mode=block",
+    x_xss_protection: str | None = Field(
+        None,
         alias="xXSSProtection",
         description="X-XSS-Protection header",
     )
-    strict_transport_security: str = Field(
-        "max-age=31536000; includeSubDomains",
+    strict_transport_security: str | None = Field(
+        None,
         alias="strictTransportSecurity",
         description="Strict-Transport-Security header",
     )
-    referrer_policy: str = Field(
-        "no-referrer",
+    referrer_policy: str | None = Field(
+        None,
         alias="referrerPolicy",
         description="Referrer-Policy header",
     )
@@ -2031,20 +2031,31 @@ class KeycloakRealmSpec(BaseModel):
         # Add browser security headers
         if self.browser_security_headers:
             headers = self.browser_security_headers
-            headers_config = {
-                "contentSecurityPolicy": headers.content_security_policy,
-                "xContentTypeOptions": headers.x_content_type_options,
-                "xFrameOptions": headers.x_frame_options,
-                "xRobotsTag": headers.x_robots_tag,
-                "xXSSProtection": headers.x_xss_protection,
-                "strictTransportSecurity": headers.strict_transport_security,
-                "referrerPolicy": headers.referrer_policy,
-            }
+            headers_config = {}
+            if headers.content_security_policy:
+                headers_config["contentSecurityPolicy"] = (
+                    headers.content_security_policy
+                )
+            if headers.x_content_type_options:
+                headers_config["xContentTypeOptions"] = headers.x_content_type_options
+            if headers.x_frame_options:
+                headers_config["xFrameOptions"] = headers.x_frame_options
+            if headers.x_robots_tag:
+                headers_config["xRobotsTag"] = headers.x_robots_tag
+            if headers.x_xss_protection:
+                headers_config["xXSSProtection"] = headers.x_xss_protection
+            if headers.strict_transport_security:
+                headers_config["strictTransportSecurity"] = (
+                    headers.strict_transport_security
+                )
+            if headers.referrer_policy:
+                headers_config["referrerPolicy"] = headers.referrer_policy
             if headers.content_security_policy_report_only:
                 headers_config["contentSecurityPolicyReportOnly"] = (
                     headers.content_security_policy_report_only
                 )
-            config["browserSecurityHeaders"] = headers_config
+            if headers_config:
+                config["browserSecurityHeaders"] = headers_config
 
         # Add SMTP configuration
         if self.smtp_server:

--- a/tests/unit/models/test_realm_security_headers.py
+++ b/tests/unit/models/test_realm_security_headers.py
@@ -4,19 +4,16 @@ from keycloak_operator.models.realm import (
 )
 
 
-def test_browser_security_headers_defaults():
-    """Test default values for browser security headers."""
+def test_browser_security_headers_defaults_are_none():
+    """Test that default values for browser security headers are None (use Keycloak defaults)."""
     headers = KeycloakBrowserSecurityHeaders()
-    assert (
-        headers.content_security_policy
-        == "frame-src 'self'; frame-ancestors 'self'; object-src 'none';"
-    )
-    assert headers.x_content_type_options == "nosniff"
-    assert headers.x_frame_options == "SAMEORIGIN"
-    assert headers.x_robots_tag == "none"
-    assert headers.x_xss_protection == "1; mode=block"
-    assert headers.strict_transport_security == "max-age=31536000; includeSubDomains"
-    assert headers.referrer_policy == "no-referrer"
+    assert headers.content_security_policy is None
+    assert headers.x_content_type_options is None
+    assert headers.x_frame_options is None
+    assert headers.x_robots_tag is None
+    assert headers.x_xss_protection is None
+    assert headers.strict_transport_security is None
+    assert headers.referrer_policy is None
     assert headers.content_security_policy_report_only is None
 
 
@@ -38,8 +35,8 @@ def test_realm_spec_with_security_headers():
         == "default-src 'self';"
     )
     assert config["browserSecurityHeaders"]["xFrameOptions"] == "DENY"
-    # Defaults should be preserved if not overridden
-    assert config["browserSecurityHeaders"]["xContentTypeOptions"] == "nosniff"
+    # Unset fields should NOT be in config
+    assert "xContentTypeOptions" not in config["browserSecurityHeaders"]
 
 
 def test_realm_spec_without_security_headers():
@@ -49,4 +46,18 @@ def test_realm_spec_without_security_headers():
     )
 
     config = spec.to_keycloak_config(include_flow_bindings=False)
+    assert "browserSecurityHeaders" not in config
+
+
+def test_realm_spec_with_empty_security_headers_object():
+    """Test realm spec with empty security headers object."""
+    headers = KeycloakBrowserSecurityHeaders()
+    spec = KeycloakRealmSpec(
+        realmName="test-realm",
+        operatorRef={"namespace": "test-ns"},
+        browserSecurityHeaders=headers,
+    )
+
+    config = spec.to_keycloak_config(include_flow_bindings=False)
+    # Should not include empty browserSecurityHeaders dict
     assert "browserSecurityHeaders" not in config


### PR DESCRIPTION
## Summary
This PR fixes the default values for `browserSecurityHeaders` in the `keycloak-realm` chart and the operator model, addressing review comments from #562 which was merged prematurely.

### Changes
- **Values.yaml**: Set default values to empty strings ("") to allow Keycloak to use its built-in defaults.
- **Templates**: Updated `realm.yaml` to conditionally render header fields only if they are non-empty.
- **Operator Model**: Updated `KeycloakBrowserSecurityHeaders` model to make fields optional (`None` default) and ensure `to_keycloak_config` filters out unset fields.
- **Tests**: Updated unit tests to verify the new behavior.

This ensures that if the user does not configure these headers, the Operator does not send them to Keycloak, allowing Keycloak's defaults to apply.