### PR TITLE
ci: fix coverage combination and add validation

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -35,6 +35,7 @@ runs:
       if: always()
       with:
         name: unit-coverage
+        include-hidden-files: true
         path: |
           .coverage
           coverage.xml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -457,10 +457,28 @@ tasks:
         fi
 
         if [ "{{default "false" .COVERAGE}}" = "true" ]; then
-          echo "Retrieving coverage data..."
+          echo "Retrieving coverage data from pod..."
           if ! bash scripts/retrieve-coverage.sh; then
             echo "❌ Failed to retrieve coverage data via scripts/retrieve-coverage.sh"
             exit 1
+          fi
+
+          # Ensure that at least one integration coverage file was retrieved
+          if ! find .tmp/coverage -maxdepth 1 -type f -name '.coverage*' | grep -q .; then
+            echo "❌ No integration coverage files (.tmp/coverage/.coverage*) were found after retrieval."
+            echo "   This usually means integration coverage was not produced or retrieval failed silently."
+            exit 1
+          fi
+
+          # Ensure unit coverage is in the root where combine-coverage.sh expects it
+          if [ ! -f ".coverage" ]; then
+            if [ -n "$CI" ]; then
+              echo "❌ Unit .coverage file missing in CI."
+              echo "   Failing fast to avoid generating coverage.xml with integration-only coverage."
+              exit 1
+            else
+              echo "⚠️ Unit .coverage file missing. combine-coverage.sh will use integration-only coverage."
+            fi
           fi
 
           echo "Combining coverage data..."

--- a/scripts/combine-coverage.sh
+++ b/scripts/combine-coverage.sh
@@ -39,9 +39,15 @@ fi
 
 # Build list of coverage files to combine
 COMBINE_ARGS=()
+
+# If unit test coverage exists, rename it to be treated as a partial file
+# preventing 'input file is also output file' collisions
 if [ -f ".coverage" ]; then
-    COMBINE_ARGS+=(".coverage")
+    log "Found unit test coverage (.coverage), renaming to .coverage.unit for combination"
+    mv .coverage .coverage.unit
+    COMBINE_ARGS+=(".coverage.unit")
 fi
+
 # Add integration coverage files (glob may expand to nothing)
 for f in "${COVERAGE_DIR}"/.coverage*; do
     [ -e "$f" ] && COMBINE_ARGS+=("$f")

--- a/scripts/retrieve-coverage.sh
+++ b/scripts/retrieve-coverage.sh
@@ -18,8 +18,9 @@ COVERAGE_SRC_PATH="/tmp/coverage"
 log "Retrieving coverage data from operator pod..."
 
 # Create local coverage directory
+rm -rf "${COVERAGE_DIR}"
 mkdir -p "${COVERAGE_DIR}"
-log "Created coverage directory: ${COVERAGE_DIR}"
+log "Cleaned and created coverage directory: ${COVERAGE_DIR}"
 
 # Find operator pod
 log "Looking for operator pod with selector: ${LABEL_SELECTOR} in namespace: ${NAMESPACE}"


### PR DESCRIPTION
## Summary
Coverage was still below expected levels because `combine-coverage.sh` was silently failing to find the unit test `.coverage` file in CI, leading to reports containing only integration test results (or vice versa).

## Changes
- Added validation to `Taskfile.yml` to ensure integration coverage files are actually retrieved.
- Added a diagnostic check to `Taskfile.yml` to verify the presence of the unit test `.coverage` file before combination.
- Improved log output during the coverage collection phase.

This addresses the "silent failure" mentioned in PR #558 and ensures both unit and integration coverage are correctly combined before uploading to Codecov.