### PR TITLE
feat(operator): add circuit breaker for Keycloak API calls

### DIFF
--- a/charts/keycloak-operator/templates/03_operator_deployment.yaml
+++ b/charts/keycloak-operator/templates/03_operator_deployment.yaml
@@ -102,6 +102,14 @@ spec:
           value: {{ .Values.operator.rateLimiting.namespace.tps | quote }}
         - name: KEYCLOAK_API_NAMESPACE_BURST
           value: {{ .Values.operator.rateLimiting.namespace.burst | quote }}
+        - name: KEYCLOAK_API_CIRCUIT_BREAKER_ENABLED
+          value: {{ .Values.operator.circuitBreaker.enabled | quote }}
+        - name: KEYCLOAK_API_CIRCUIT_BREAKER_FAILURE_THRESHOLD
+          value: {{ .Values.operator.circuitBreaker.failureThreshold | quote }}
+        - name: KEYCLOAK_API_CIRCUIT_BREAKER_RECOVERY_TIMEOUT
+          value: {{ .Values.operator.circuitBreaker.recoveryTimeout | quote }}
+        - name: KEYCLOAK_API_TIMEOUT_SECONDS
+          value: {{ .Values.operator.circuitBreaker.apiTimeout | quote }}
         - name: RECONCILE_JITTER_MAX_SECONDS
           value: {{ .Values.operator.reconciliation.jitterMaxSeconds | quote }}
         - name: DRIFT_DETECTION_ENABLED

--- a/charts/keycloak-operator/values.schema.json
+++ b/charts/keycloak-operator/values.schema.json
@@ -323,6 +323,35 @@
             }
           }
         },
+        "circuitBreaker": {
+          "type": "object",
+          "description": "Circuit breaker configuration to protect Keycloak from overload",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable circuit breaker for Keycloak API calls",
+              "default": true
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "description": "Number of consecutive failures before opening the circuit",
+              "default": 5,
+              "minimum": 1
+            },
+            "recoveryTimeout": {
+              "type": "integer",
+              "description": "Time in seconds to wait before attempting recovery (half-open state)",
+              "default": 30,
+              "minimum": 1
+            },
+            "apiTimeout": {
+              "type": "integer",
+              "description": "Request timeout in seconds for Keycloak API calls",
+              "default": 30,
+              "minimum": 1
+            }
+          }
+        },
         "metrics": {
           "type": "object",
           "description": "Metrics server configuration",

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -152,6 +152,17 @@ operator:
       tps: 5.0
       # Maximum burst per namespace
       burst: 10
+  # Circuit Breaker Configuration
+  # Protects the operator and Keycloak from overload during high failure rates
+  circuitBreaker:
+    # Enable circuit breaker for Keycloak API calls
+    enabled: true
+    # Number of consecutive failures before opening the circuit
+    failureThreshold: 5
+    # Time in seconds to wait before attempting recovery (half-open state)
+    recoveryTimeout: 30
+    # Request timeout in seconds for Keycloak API calls
+    apiTimeout: 30
   # Metrics server configuration
   metrics:
     # Port to expose Prometheus metrics on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "urllib3>=2.6.3",  # CVE-2026-21441 fix
     "pyasn1>=0.6.2",   # CVE-2026-23490 fix
+    "aiobreaker>=1.0.0",
 ]
 
 [project.urls]

--- a/src/keycloak_operator/observability/metrics.py
+++ b/src/keycloak_operator/observability/metrics.py
@@ -181,6 +181,17 @@ RATE_LIMIT_BUDGET_AVAILABLE = Gauge(
 )
 
 # ---------------------------------------------------------------------------
+# Circuit Breaker metrics
+# ---------------------------------------------------------------------------
+
+CIRCUIT_BREAKER_STATE = Gauge(
+    "keycloak_operator_circuit_breaker_state",
+    "Circuit breaker state (0=closed/healthy, 1=open/broken, 2=half-open/recovering)",
+    ["keycloak_instance", "keycloak_namespace"],
+    registry=None,
+)
+
+# ---------------------------------------------------------------------------
 # Leader election metrics (namespace label removed – single-namespace deploy)
 # ---------------------------------------------------------------------------
 
@@ -351,6 +362,7 @@ def get_metrics_registry() -> CollectorRegistry:
             RATE_LIMIT_ACQUIRED_TOTAL,
             RATE_LIMIT_TIMEOUTS_TOTAL,
             RATE_LIMIT_BUDGET_AVAILABLE,
+            CIRCUIT_BREAKER_STATE,
             LEADER_ELECTION_STATUS,
             LEADER_ELECTION_CHANGES,
             LEADER_ELECTION_LEASE_RENEWALS,

--- a/src/keycloak_operator/settings.py
+++ b/src/keycloak_operator/settings.py
@@ -183,6 +183,28 @@ class Settings(BaseSettings):
         description="Per-namespace burst capacity for Keycloak API rate limiting",
     )
 
+    # Circuit Breaker Configuration
+    api_circuit_breaker_enabled: bool = Field(
+        default=True,
+        validation_alias="KEYCLOAK_API_CIRCUIT_BREAKER_ENABLED",
+        description="Enable circuit breaker for Keycloak API calls",
+    )
+    api_circuit_breaker_failure_threshold: int = Field(
+        default=5,
+        validation_alias="KEYCLOAK_API_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
+        description="Number of consecutive failures before opening the circuit",
+    )
+    api_circuit_breaker_recovery_timeout: int = Field(
+        default=30,
+        validation_alias="KEYCLOAK_API_CIRCUIT_BREAKER_RECOVERY_TIMEOUT",
+        description="Time in seconds to wait before attempting recovery (half-open state)",
+    )
+    api_timeout_seconds: int = Field(
+        default=30,
+        validation_alias="KEYCLOAK_API_TIMEOUT_SECONDS",
+        description="Request timeout in seconds for Keycloak API calls",
+    )
+
     # Reconciliation behavior
     reconcile_jitter_max_seconds: float = Field(
         default=5.0,

--- a/src/keycloak_operator/utils/circuit_breaker.py
+++ b/src/keycloak_operator/utils/circuit_breaker.py
@@ -1,0 +1,122 @@
+"""
+Circuit breaker implementation for Keycloak API calls.
+
+This module provides a wrapper around aiobreaker to protect the operator
+from overloaded Keycloak instances. It integrates with Prometheus metrics
+to track the circuit state.
+"""
+
+import logging
+from collections.abc import Callable
+from datetime import timedelta
+from typing import Any, TypeVar
+
+import aiobreaker
+from aiobreaker.state import CircuitHalfOpenState, CircuitOpenState
+
+from keycloak_operator.observability.metrics import CIRCUIT_BREAKER_STATE
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class KeycloakCircuitBreaker:
+    """
+    Circuit breaker wrapper for Keycloak Admin API client.
+
+    Wraps aiobreaker.CircuitBreaker and updates Prometheus metrics
+    on state changes.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        namespace: str,
+        fail_max: int,
+        timeout_duration: int,
+    ):
+        """
+        Initialize circuit breaker.
+
+        Args:
+            name: Keycloak instance name
+            namespace: Keycloak instance namespace
+            fail_max: Number of failures before opening the circuit
+            timeout_duration: Seconds to wait before attempting recovery (half-open)
+        """
+        self.name = name
+        self.namespace = namespace
+
+        # Define state listener to update metrics
+        class MetricsListener(aiobreaker.CircuitBreakerListener):
+            def state_change(self, breaker, old, new):
+                try:
+                    # Robustly get state name for logging
+                    old_name = getattr(old, "name", type(old).__name__)
+                    new_name = getattr(new, "name", type(new).__name__)
+
+                    logger.warning(
+                        f"Circuit breaker state changed: {old_name} -> {new_name} "
+                        f"(instance={name}, namespace={namespace})"
+                    )
+
+                    # Map state to metric value
+                    # 0 = Closed (Healthy)
+                    # 1 = Open (Broken)
+                    # 2 = Half-Open (Recovering)
+                    state_value = 0
+
+                    if (
+                        isinstance(new, CircuitOpenState)
+                        or getattr(new, "name", "").lower() == "open"
+                    ):
+                        state_value = 1
+                    elif (
+                        isinstance(new, CircuitHalfOpenState)
+                        or getattr(new, "name", "").lower() == "half-open"
+                    ):
+                        state_value = 2
+
+                    CIRCUIT_BREAKER_STATE.labels(
+                        keycloak_instance=name,
+                        keycloak_namespace=namespace,
+                    ).set(state_value)
+                except Exception as e:
+                    # Log error but don't crash
+                    logger.error(f"Error in circuit breaker listener: {e}")
+
+        self._breaker = aiobreaker.CircuitBreaker(
+            fail_max=fail_max,
+            timeout_duration=timedelta(seconds=timeout_duration),
+            listeners=[MetricsListener()],
+        )
+
+        # Initialize metric
+        CIRCUIT_BREAKER_STATE.labels(
+            keycloak_instance=name,
+            keycloak_namespace=namespace,
+        ).set(0)
+
+    async def call(self, func: Callable[..., Any], *args, **kwargs) -> Any:
+        """
+        Call a function with circuit breaker protection.
+
+        Args:
+            func: Async function to call
+            *args: Arguments for the function
+            **kwargs: Keyword arguments for the function
+
+        Returns:
+            Result of the function call
+
+        Raises:
+            aiobreaker.CircuitBreakerError: If the circuit is open
+            Exception: Whatever the function raises
+        """
+        return await self._breaker.call_async(func, *args, **kwargs)
+
+    @property
+    def current_state(self) -> str:
+        """Get current state name (lowercase)."""
+        return self._breaker.current_state.name.lower()

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -1,0 +1,124 @@
+import asyncio
+
+import pytest
+from aiobreaker import CircuitBreakerError
+
+from keycloak_operator.observability.metrics import CIRCUIT_BREAKER_STATE
+from keycloak_operator.utils.circuit_breaker import KeycloakCircuitBreaker
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_state_transitions():
+    """Test circuit breaker state transitions and metrics updates."""
+
+    # Custom exception for testing
+    class TestException(Exception):
+        pass
+
+    # Setup
+    name = "test-instance"
+    namespace = "test-namespace"
+    fail_max = 2
+    timeout_duration = 0.1  # Fast recovery for test
+
+    cb = KeycloakCircuitBreaker(
+        name=name,
+        namespace=namespace,
+        fail_max=fail_max,
+        timeout_duration=timeout_duration,
+    )
+
+    # Verify initial state (Closed = 0)
+    assert cb.current_state == "closed"
+    metrics = list(CIRCUIT_BREAKER_STATE.collect())
+    sample_value = None
+    for metric in metrics:
+        for sample in metric.samples:
+            if (
+                sample.labels["keycloak_instance"] == name
+                and sample.labels["keycloak_namespace"] == namespace
+            ):
+                sample_value = sample.value
+                break
+    assert sample_value == 0
+
+    # Failing function
+    async def failing_func():
+        raise TestException("Failed!")
+
+    # Trigger failures to open circuit
+    for i in range(fail_max):
+        # On the last failure that trips the breaker, it raises CircuitBreakerError
+        # wrapping the original exception
+        expected_exc = (
+            (TestException, CircuitBreakerError) if i == fail_max - 1 else TestException
+        )
+        with pytest.raises(expected_exc):
+            await cb.call(failing_func)
+
+    # Should now be open
+    assert cb.current_state == "open"
+
+    # Metric check
+    metrics = list(CIRCUIT_BREAKER_STATE.collect())
+    sample_value = None
+    for metric in metrics:
+        for sample in metric.samples:
+            if (
+                sample.labels["keycloak_instance"] == name
+                and sample.labels["keycloak_namespace"] == namespace
+            ):
+                sample_value = sample.value
+                break
+    assert sample_value == 1
+
+    # Call should raise CircuitBreakerError immediately
+    with pytest.raises(CircuitBreakerError):
+        await cb.call(failing_func)
+
+    # Wait for recovery timeout
+    await asyncio.sleep(timeout_duration + 0.1)
+
+    # Should be half-open (metric updates on next call attempt)
+    # Note: aiobreaker transitions to half-open lazily on next call
+
+    # Successful function
+    async def success_func():
+        return "Success"
+
+    # Next call should succeed and close circuit
+    result = await cb.call(success_func)
+    assert result == "Success"
+
+    assert cb.current_state == "closed"
+
+    metrics = list(CIRCUIT_BREAKER_STATE.collect())
+    sample_value = None
+    for metric in metrics:
+        for sample in metric.samples:
+            if (
+                sample.labels["keycloak_instance"] == name
+                and sample.labels["keycloak_namespace"] == namespace
+            ):
+                sample_value = sample.value
+                break
+    assert sample_value == 0
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_passthrough():
+    """Test that circuit breaker passes return values and exceptions."""
+    cb = KeycloakCircuitBreaker("test", "ns", 5, 1)
+
+    # Test return value
+    async def ok_func():
+        return "OK"
+
+    assert await cb.call(ok_func) == "OK"
+
+    # Test exception passthrough
+    async def err_func():
+        raise ValueError("Error")
+
+    with pytest.raises(ValueError):
+        await cb.call(err_func)

--- a/tests/unit/test_keycloak_admin_circuit_breaker.py
+++ b/tests/unit/test_keycloak_admin_circuit_breaker.py
@@ -1,0 +1,138 @@
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from keycloak_operator.settings import settings
+from keycloak_operator.utils.keycloak_admin import (
+    KeycloakAdminClient,
+    KeycloakAdminError,
+)
+
+
+@pytest.fixture
+def mock_httpx_client():
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.is_closed = False
+    return client
+
+
+@pytest.fixture
+def admin_client(mock_httpx_client):
+    # Mock settings to ensure circuit breaker is enabled
+    settings.api_circuit_breaker_enabled = True
+    settings.api_circuit_breaker_failure_threshold = 2
+    settings.api_circuit_breaker_recovery_timeout = 1  # Int value
+    settings.api_timeout_seconds = 10
+
+    with patch("keycloak_operator.utils.keycloak_admin._httpx_client_cache", {}):
+        with patch(
+            "keycloak_operator.utils.keycloak_admin.httpx.AsyncClient",
+            return_value=mock_httpx_client,
+        ):
+            client = KeycloakAdminClient(
+                server_url="http://test-server",
+                username="admin",
+                password="password",
+                keycloak_name="test-instance",
+                keycloak_namespace="test-namespace",
+            )
+            # Mock authentication to avoid real network calls
+            client.access_token = "fake-token"
+            # Use time.time() instead of asyncio loop time for robustness in fixtures
+            client.token_expires_at = time.time() + 3600
+            yield client
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_opens_on_failures(admin_client, mock_httpx_client):
+    """Test that circuit breaker opens after threshold failures."""
+    # Setup mock to raise exceptions
+    mock_httpx_client.request.side_effect = httpx.ConnectError("Connection failed")
+
+    # Fail 1
+    with pytest.raises(KeycloakAdminError):
+        await admin_client._make_request("GET", "realms", "default")
+
+    # Fail 2 (threshold reached)
+    with pytest.raises(KeycloakAdminError):
+        await admin_client._make_request("GET", "realms", "default")
+
+    # Should be open now
+    assert admin_client.circuit_breaker.current_state == "open"
+
+    # Next call should fail fast with 503 from KeycloakAdminError (wrapping CircuitBreakerError)
+    # We reset side effect to ensure it's the circuit breaker raising, not the mock
+    mock_httpx_client.request.side_effect = None
+
+    with pytest.raises(KeycloakAdminError) as exc_info:
+        await admin_client._make_request("GET", "realms", "default")
+
+    assert exc_info.value.status_code == 503
+    assert "Circuit breaker open" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_retry_on_401_bypasses_circuit_breaker(admin_client, mock_httpx_client):
+    """Test that 401 retry logic doesn't double-count against circuit breaker."""
+    # First request returns 401, second returns 200
+    mock_response_401 = MagicMock(spec=httpx.Response)
+    mock_response_401.status_code = 401
+
+    mock_response_200 = MagicMock(spec=httpx.Response)
+    mock_response_200.status_code = 200
+    mock_response_200.json.return_value = {"token": "new-token"}
+
+    # Mock authenticate to avoid recursion
+    with patch.object(admin_client, "authenticate", new_callable=AsyncMock):
+        # Sequence:
+        # 1. First request -> 401
+        # 2. Authenticate called
+        # 3. Retry request -> 200
+        mock_httpx_client.request.side_effect = [mock_response_401, mock_response_200]
+
+        response = await admin_client._make_request("GET", "realms", "default")
+
+        assert response.status_code == 200
+        # Circuit breaker should still be closed (401 is not a failure for CB)
+        assert admin_client.circuit_breaker.current_state == "closed"
+
+        # Should have called request twice
+        assert mock_httpx_client.request.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_metrics_updated_on_state_change(admin_client, mock_httpx_client):
+    """Test that Prometheus metrics are updated when circuit state changes."""
+    from keycloak_operator.observability.metrics import CIRCUIT_BREAKER_STATE
+
+    # Verify initial metric state
+    # Reset metric for this test
+    CIRCUIT_BREAKER_STATE.clear()
+    # Initialize it (constructor does this)
+    CIRCUIT_BREAKER_STATE.labels(
+        keycloak_instance="test-instance",
+        keycloak_namespace="test-namespace",
+    ).set(0)
+
+    # Make it fail
+    mock_httpx_client.request.side_effect = httpx.ConnectError("Connection failed")
+
+    # Fail until open
+    for _ in range(2):
+        with pytest.raises(KeycloakAdminError):
+            await admin_client._make_request("GET", "realms", "default")
+
+    # Check metric is now 1 (Open)
+    metrics = list(CIRCUIT_BREAKER_STATE.collect())
+    samples = metrics[0].samples if metrics else []
+    for sample in samples:
+        if (
+            sample.labels["keycloak_instance"] == "test-instance"
+            and sample.labels["keycloak_namespace"] == "test-namespace"
+        ):
+            assert sample.value == 1.0
+            break
+    else:
+        pytest.fail("Metric not found")

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "aiobreaker"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/eb/749ef48d3227fd62d500ff01fcd451f10111e00d822c200eb51782ba076a/aiobreaker-1.2.0.tar.gz", hash = "sha256:217a9cfa12e520bb2dd1934bace281d1d7deb8d7630dd183a6295fd22e323ce7", size = 15947, upload-time = "2021-05-17T11:58:05.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/c8/4cd4b2834012ffc71ae3fd69187f08a17f01f3937527b6b5e077f4f5d0db/aiobreaker-1.2.0-py3-none-any.whl", hash = "sha256:f275decad78bdd161715afeee67e5dde7967de54c836648b44f4eea1b5e41d60", size = 20700, upload-time = "2021-05-17T11:58:04.192Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -762,6 +771,7 @@ name = "keycloak-operator"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiobreaker" },
     { name = "aiohttp" },
     { name = "asyncpg" },
     { name = "httpx" },
@@ -844,6 +854,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiobreaker", specifier = ">=1.0.0" },
     { name = "aiohttp", specifier = ">=3.10.11" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary
This PR implements a circuit breaker pattern for Keycloak Admin API calls to protect the operator and Keycloak from overload during high failure rates.

Key features:
- Uses `aiobreaker` library for circuit breaker logic.
- Wraps `KeycloakAdminClient` requests.
- Configurable failure threshold and recovery timeout.
- Integrates with Prometheus metrics to track circuit state.

## Changes
- Added `aiobreaker` dependency.
- Added circuit breaker configuration to `Settings`.
- Created `KeycloakCircuitBreaker` wrapper in `src/keycloak_operator/utils/circuit_breaker.py`.
- Updated `KeycloakAdminClient` to use circuit breaker.
- Added `keycloak_operator_circuit_breaker_state` metric.
- Added unit tests.

## Testing
- Added unit tests for circuit breaker state transitions and metrics.
- Verified existing unit tests pass.

Fixes #169