### PR TITLE
fix(chart-operator): update for operator v0.7.25

### DIFF
--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: keycloak-operator
 description: A Helm chart for deploying the Keycloak Operator with GitOps compatibility
 type: application
 version: 0.4.32
-appVersion: "v0.7.23"
+appVersion: "v0.7.25"
 keywords:
   - keycloak
   - operator

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -37,7 +37,7 @@ operator:
     # Overrides the image tag whose default is the chart appVersion.
     # This is automatically updated by the update-chart-versions workflow on new releases
     # Example: "v0.3.2" or "latest"
-    tag: "v0.7.23"
+    tag: "v0.7.25"
   # Image pull secrets for private registries
   # Example:
   # imagePullSecrets:
@@ -419,26 +419,20 @@ keycloak:
   # If true, the chart templates a Keycloak CR and auto-calculates connection URLs.
   # If false, you must provide 'url' and 'adminSecret' for an existing Keycloak.
   managed: true
-
   # Name of the Keycloak instance (used for CR name and service naming)
   name: "keycloak"
-
   # URL of the Keycloak instance.
   # If managed is true, this is auto-calculated to the internal cluster service.
   # Example: "https://keycloak.example.com"
   url: ""
-
   # Admin username for initial access
   adminUsername: "admin"
-
   # Name of the Secret containing the admin password.
   # If managed is true, this defaults to "<name>-admin-credentials".
   # If managed is false, this secret must exist in the operator's namespace.
   adminSecret: ""
-
   # Key in the adminSecret containing the password.
   adminPasswordKey: "password"
-
   # Keycloak version to deploy (used when managed: true)
   version: "26.1.2"
   # Container image for Keycloak (used when managed: true)


### PR DESCRIPTION
Updates operator chart to use operator version `v0.7.25`.

**Changes:**
- Updated `charts/keycloak-operator/values.yaml` image tag
- Updated `charts/keycloak-operator/Chart.yaml` appVersion

This fix ensures the chart is compatible with operator v0.7.25.

🤖 Auto-generated by CI/CD workflow