### PR TITLE
docs: add disaster recovery guide (#91)

### DIFF
--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -18,17 +18,17 @@ What you need in addition to your CRD manifests is a healthy **Keycloak database
 
 Whether a database restore is worth your operational investment depends on what you use Keycloak for. This table helps you decide:
 
-| What might be lost | Lost without DB restore? | Notes |
-|--------------------|--------------------------|-------|
-| Realm configuration | **No** — recovered from CRDs | Operator re-creates on reconcile |
-| Client configuration | **No** — recovered from CRDs | Operator re-creates on reconcile |
-| IdP / SSO federation settings | **No** — recovered from CRDs | Re-created from spec |
-| Registered user accounts | **Yes** | Passwords, attributes, MFA enrollments |
-| User role assignments | **Yes** | Must be re-assigned or re-imported |
-| Active OAuth sessions | **Yes** — but acceptable | Users simply re-authorize |
-| Operator-managed client secrets | Partial — see below | Operator regenerates on reconcile; external consumers need to pick up the new value |
-| Manually copied client secrets | **Yes** | If you copied a secret out-of-band, it will not match the newly generated one |
-| Keycloak audit / admin event log | **Yes** — usually acceptable | Purely historical |
+| What | Survives without DB restore? | Notes |
+|------|------------------------------|-------|
+| Realm configuration | ✅ Recovered from CRDs | Operator re-creates on reconcile |
+| Client configuration | ✅ Recovered from CRDs | Operator re-creates on reconcile |
+| IdP / SSO federation settings | ✅ Recovered from CRDs | Re-created from spec |
+| Active OAuth sessions | ⚠️ Lost — usually acceptable | Users simply re-authorize |
+| Keycloak audit / admin event log | ⚠️ Lost — usually acceptable | Purely historical |
+| Operator-managed client secrets | ⚠️ Changed — see below | Operator generates a new secret; consumers need to pick up the new value |
+| Manually bound client secrets | ✅ Preserved | Operator reads from your referenced Secret, syncs that value to Keycloak |
+| Registered user accounts | ❌ Lost | Passwords, attributes, MFA enrollments |
+| User role assignments | ❌ Lost | Must be re-assigned or re-imported |
 
 **The guiding principle:** the more Keycloak is a pass-through to an upstream IdP (Azure AD, Google, GitHub), the less your database matters. If users log in with their corporate SSO and Keycloak holds no local credentials, losing the database and re-applying your CRDs is a full recovery.
 
@@ -38,14 +38,30 @@ The more Keycloak is the identity source — local accounts, password-based logi
 
 ## Client secrets and automated rotation
 
-When the operator manages a client secret (`manageSecret: true` with rotation enabled), a database loss followed by a re-apply of your CRDs will cause the operator to **regenerate the client secret** and write the new value into the Kubernetes Secret in your namespace. Applications that read the Secret directly from the cluster — the intended pattern — will pick up the new value on their next restart or secret refresh.
+How the operator handles client secrets after a recovery depends on whether the Kubernetes Secret still exists:
 
-The problem arises when a secret has been **manually copied to a location outside the cluster** — for example, into an environment variable in a CI system, a `.env` file on a server, or a secrets store populated by hand. Those external copies will be stale and authentication will fail silently until they are updated.
+**If the Kubernetes Secret survives** (e.g., only Keycloak's database was lost, or you restored from a cluster backup): the operator reads the secret value from the existing Kubernetes Secret and syncs it back to the freshly initialized Keycloak. The value is unchanged. No consumers are affected.
 
-If you have consumers outside the cluster, see the [Secret Management guide](./secret-management.md) for how to:
+**If the Kubernetes Secret is gone** (e.g., full cluster loss without a cluster backup, and no database restore): the operator creates the client fresh in Keycloak and generates a new secret. That new value is written into a new Kubernetes Secret in your namespace. Anything that was consuming the old value now has a mismatch.
 
-- Automate pod restarts when a managed secret changes (Stakater Reloader, Kyverno)
-- Configure notifications or pipelines for external consumers on rotation events
+### In-cluster applications
+
+Applications that mount the Kubernetes Secret as a volume or environment variable will have stale values until their pods are restarted. Kubernetes does not automatically restart pods when a Secret changes.
+
+Use [Stakater Reloader](https://github.com/stakater/Reloader) or a [Kyverno restart policy](./secret-management.md#kyverno-restart-policy) to automate this. See the [Secret Management guide](./secret-management.md) for configuration examples.
+
+### Out-of-cluster consumers
+
+If you manually copied a client secret value somewhere outside the cluster — a CI/CD secret variable, a `.env` file, a cloud secrets manager entry — that copy is now wrong and there is no automated path to fix it. You need to export the new value from the Kubernetes Secret and update every external location by hand:
+
+```bash
+kubectl get secret <client-name>-credentials -n <namespace> \
+  -o jsonpath='{.data.client-secret}' | base64 -d
+```
+
+The only way to avoid this problem is to not copy secret values out-of-band in the first place. If you need the secret available outside the cluster, use a tool like [External Secrets Operator](https://external-secrets.io/) to continuously sync the Kubernetes Secret to your external store — so when the secret changes, the sync propagates the new value automatically.
+
+Alternatively, pin the secret to a known value from the start by using `spec.clientSecret` (a reference to a Kubernetes Secret you control) rather than operator-managed generation. When a manually bound secret is used, the operator always reads from your referenced Secret and pushes that value to Keycloak — so you control the value and a recovery never changes it unexpectedly.
 
 ---
 

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -1,0 +1,77 @@
+# Disaster Recovery
+
+This page covers what you actually lose when things go wrong, the correct order to bring things back, and where to find instructions for specific scenarios.
+
+---
+
+## Your GitOps repository is your primary recovery mechanism
+
+The operator is stateless. Every Keycloak realm, client, and configuration setting is declared in your `KeycloakRealm` and `KeycloakClient` CRDs. When the operator is running and those CRDs exist in the cluster, it will reconcile them to the desired state without any manual intervention.
+
+If you store your CRD manifests in a Git repository — which is the intended deployment model — re-applying them is enough to reconstruct the configuration side of Keycloak. You do not need a special operator recovery procedure.
+
+What you need in addition to your CRD manifests is a healthy **Keycloak database**. That is it.
+
+---
+
+## What you lose without a database restore
+
+Whether a database restore is worth your operational investment depends on what you use Keycloak for. This table helps you decide:
+
+| What might be lost | Lost without DB restore? | Notes |
+|--------------------|--------------------------|-------|
+| Realm configuration | **No** — recovered from CRDs | Operator re-creates on reconcile |
+| Client configuration | **No** — recovered from CRDs | Operator re-creates on reconcile |
+| IdP / SSO federation settings | **No** — recovered from CRDs | Re-created from spec |
+| Registered user accounts | **Yes** | Passwords, attributes, MFA enrollments |
+| User role assignments | **Yes** | Must be re-assigned or re-imported |
+| Active OAuth sessions | **Yes** — but acceptable | Users simply re-authorize |
+| Operator-managed client secrets | Partial — see below | Operator regenerates on reconcile; external consumers need to pick up the new value |
+| Manually copied client secrets | **Yes** | If you copied a secret out-of-band, it will not match the newly generated one |
+| Keycloak audit / admin event log | **Yes** — usually acceptable | Purely historical |
+
+**The guiding principle:** the more Keycloak is a pass-through to an upstream IdP (Azure AD, Google, GitHub), the less your database matters. If users log in with their corporate SSO and Keycloak holds no local credentials, losing the database and re-applying your CRDs is a full recovery.
+
+The more Keycloak is the identity source — local accounts, password-based login, self-registration — the more critical a timely database backup becomes.
+
+---
+
+## Client secrets and automated rotation
+
+When the operator manages a client secret (`manageSecret: true` with rotation enabled), a database loss followed by a re-apply of your CRDs will cause the operator to **regenerate the client secret** and write the new value into the Kubernetes Secret in your namespace. Applications that read the Secret directly from the cluster — the intended pattern — will pick up the new value on their next restart or secret refresh.
+
+The problem arises when a secret has been **manually copied to a location outside the cluster** — for example, into an environment variable in a CI system, a `.env` file on a server, or a secrets store populated by hand. Those external copies will be stale and authentication will fail silently until they are updated.
+
+If you have consumers outside the cluster, see the [Secret Management guide](./secret-management.md) for how to:
+
+- Automate pod restarts when a managed secret changes (Stakater Reloader, Kyverno)
+- Configure notifications or pipelines for external consumers on rotation events
+
+---
+
+## Recovery order
+
+When recovering from a failure that involved data loss:
+
+1. **Restore the Keycloak database first.** Keycloak must be able to connect to a working database before it starts. Starting Keycloak against an empty database will initialize a blank instance.
+
+2. **Bring up Keycloak** (or let the operator deploy it, if you use a managed Keycloak CR).
+
+3. **Ensure the operator is running** and your CRDs are present in the cluster. The operator will reconcile immediately. No manual trigger is needed.
+
+If the operator comes up before the database is ready, Keycloak will report unhealthy and the operator will set the status to `Degraded`. This self-corrects once the database is available — no action required.
+
+---
+
+## Common scenarios
+
+For situations that land you on this page, here is where to find the relevant procedure:
+
+| Scenario | Where to look |
+|----------|--------------|
+| Keycloak database lost or corrupted | Restore from your database provider's backup (CNPG, managed PostgreSQL, cloud provider snapshot). Then follow the recovery order above. For configuring automated pre-upgrade backups with CNPG, see [Backup & Restore](./backup-restore.md). |
+| Operator pod or namespace deleted | Re-deploy via Helm. No data loss — CRDs survive namespace deletion. Operator reconciles on startup. |
+| Entire cluster lost | Restore your database, recreate the cluster, apply your GitOps manifests. The rest follows from the order above. |
+| Migrating Keycloak to a different instance or cluster | See the [Migration & Upgrade guide](./migration.md) and [Escape Hatch](./escape-hatch.md). |
+| Drift detector marking resources as orphaned | See [Troubleshooting](./troubleshooting.md). |
+| Client secret mismatch after recovery | See [Secret Management](./secret-management.md). |

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -6,11 +6,11 @@ This page covers what you actually lose when things go wrong, the correct order 
 
 ## Your GitOps repository is your primary recovery mechanism
 
-The operator is stateless. Every Keycloak realm, client, and configuration setting is declared in your `KeycloakRealm` and `KeycloakClient` CRDs. When the operator is running and those CRDs exist in the cluster, it will reconcile them to the desired state without any manual intervention.
+The operator is stateless. Your desired Keycloak state is declared through your `Keycloak`, `KeycloakRealm`, and `KeycloakClient` resources, together with any referenced Kubernetes Secrets and Helm deployment values. When the operator is running and those resources exist in the cluster, it will reconcile them to the desired state without any manual intervention.
 
-If you store your CRD manifests in a Git repository — which is the intended deployment model — re-applying them is enough to reconstruct the configuration side of Keycloak. You do not need a special operator recovery procedure.
+If you store those manifests and referenced inputs in a Git repository — which is the intended deployment model — re-applying them is enough to reconstruct the configuration side of Keycloak. You do not need a special operator recovery procedure.
 
-What you need in addition to your CRD manifests is a healthy **Keycloak database**. That is it.
+What you need in addition to those declarative resources is a healthy **Keycloak database**. That is it.
 
 ---
 
@@ -48,9 +48,9 @@ The authoritative source for client secrets is the **Keycloak database**. How re
 
 ### In-cluster applications (without a database restore)
 
-Applications that mount the credentials Secret as a volume or environment variable will have stale values until their pods are restarted. Kubernetes does not automatically restart pods when a Secret changes.
+Applications that consume the credentials Secret through environment variables will keep the old value until their pods are restarted. Applications that mount the Secret as a volume usually see the updated files automatically after a short delay, but the application may still need a restart or reload to begin using the new value.
 
-Use Stakater Reloader or a Kyverno restart policy to automate this. See the [Secret Management guide](./secret-management.md) for configuration examples.
+Kubernetes does not automatically restart pods when a Secret changes, so tools such as Stakater Reloader or a Kyverno restart policy are a practical way to automate updates for workloads that need a restart or reload. See the [Secret Management guide](./secret-management.md) for configuration examples.
 
 ### Out-of-cluster consumers (without a database restore)
 
@@ -88,7 +88,7 @@ For situations that land you on this page, here is where to find the relevant pr
 | Scenario | Where to look |
 |----------|--------------|
 | Keycloak database lost or corrupted | Restore from your database provider's backup (CNPG, managed PostgreSQL, cloud provider snapshot). Then follow the recovery order above. For configuring automated pre-upgrade backups with CNPG, see [Backup & Restore](./backup-restore.md). |
-| Operator pod or namespace deleted | Re-deploy via Helm. No data loss — CRDs survive namespace deletion. Operator reconciles on startup. |
+| Operator pod or namespace deleted | Re-deploy via Helm. If only the operator pod or deployment was deleted, there is no data loss and the operator will reconcile on startup. If the namespace was deleted, all namespaced resources in it (including Keycloak CRs and Secrets) were deleted too — after recreating the namespace, re-apply your GitOps manifests and restore Secrets as needed. |
 | Entire cluster lost | Restore your database, recreate the cluster, apply your GitOps manifests. The rest follows from the order above. |
 | Migrating Keycloak to a different instance or cluster | See the [Migration & Upgrade guide](./migration.md) and [Escape Hatch](./escape-hatch.md). |
 | Drift detector marking resources as orphaned | See [Troubleshooting](./troubleshooting.md). |

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -38,30 +38,32 @@ The more Keycloak is the identity source — local accounts, password-based logi
 
 ## Client secrets and automated rotation
 
-How the operator handles client secrets after a recovery depends on whether the Kubernetes Secret still exists:
+The authoritative source for client secrets is the **Keycloak database**. How recovery affects your consumers depends on whether you restored that database and how the client was configured.
 
-**If the Kubernetes Secret survives** (e.g., only Keycloak's database was lost, or you restored from a cluster backup): the operator reads the secret value from the existing Kubernetes Secret and syncs it back to the freshly initialized Keycloak. The value is unchanged. No consumers are affected.
+**With a database restore**: Keycloak has the same secret values as before. The operator reads them back from Keycloak and writes them into the credentials Secrets in your namespaces. Values are unchanged. No consumers are affected.
 
-**If the Kubernetes Secret is gone** (e.g., full cluster loss without a cluster backup, and no database restore): the operator creates the client fresh in Keycloak and generates a new secret. That new value is written into a new Kubernetes Secret in your namespace. Anything that was consuming the old value now has a mismatch.
+**Without a database restore**: Keycloak creates each client fresh with a new randomly generated secret. The new value is written into the credentials Secrets in your namespaces. Anything that was consuming the old value now has a mismatch until updated.
 
-### In-cluster applications
+**With a manually bound secret** (`spec.clientSecret`): the operator always reads the secret value from your referenced Kubernetes Secret and pushes it to Keycloak, regardless of what Keycloak currently has. If Keycloak was re-initialized, the operator will sync your value back into it. The credentials Secret in your namespace reflects your value. No consumers are affected.
 
-Applications that mount the Kubernetes Secret as a volume or environment variable will have stale values until their pods are restarted. Kubernetes does not automatically restart pods when a Secret changes.
+### In-cluster applications (without a database restore)
 
-Use [Stakater Reloader](https://github.com/stakater/Reloader) or a [Kyverno restart policy](./secret-management.md#kyverno-restart-policy) to automate this. See the [Secret Management guide](./secret-management.md) for configuration examples.
+Applications that mount the credentials Secret as a volume or environment variable will have stale values until their pods are restarted. Kubernetes does not automatically restart pods when a Secret changes.
 
-### Out-of-cluster consumers
+Use Stakater Reloader or a Kyverno restart policy to automate this. See the [Secret Management guide](./secret-management.md) for configuration examples.
 
-If you manually copied a client secret value somewhere outside the cluster — a CI/CD secret variable, a `.env` file, a cloud secrets manager entry — that copy is now wrong and there is no automated path to fix it. You need to export the new value from the Kubernetes Secret and update every external location by hand:
+### Out-of-cluster consumers (without a database restore)
+
+If you copied a client secret value somewhere outside the cluster — a CI/CD secret variable, a `.env` file, a cloud secrets manager — that copy is now wrong. There is no automated path to fix it. You need to export the new value and update every external location by hand:
 
 ```bash
 kubectl get secret <client-name>-credentials -n <namespace> \
   -o jsonpath='{.data.client-secret}' | base64 -d
 ```
 
-The only way to avoid this problem is to not copy secret values out-of-band in the first place. If you need the secret available outside the cluster, use a tool like [External Secrets Operator](https://external-secrets.io/) to continuously sync the Kubernetes Secret to your external store — so when the secret changes, the sync propagates the new value automatically.
+If you need client secrets available outside the cluster, use a tool like [External Secrets Operator](https://external-secrets.io/) to continuously sync the credentials Secret to your external store. When the value changes, the sync propagates it automatically.
 
-Alternatively, pin the secret to a known value from the start by using `spec.clientSecret` (a reference to a Kubernetes Secret you control) rather than operator-managed generation. When a manually bound secret is used, the operator always reads from your referenced Secret and pushes that value to Keycloak — so you control the value and a recovery never changes it unexpectedly.
+Alternatively, use `spec.clientSecret` to bind the client to a Kubernetes Secret you control. The operator will always push your value to Keycloak, so recovery never generates a new value unexpectedly.
 
 ---
 

--- a/docs/operations/migration.md
+++ b/docs/operations/migration.md
@@ -4,6 +4,9 @@ This guide covers operator upgrades, managed Keycloak upgrades, and migration gu
 
 For supported Keycloak versions, use [Keycloak Version Support](../reference/keycloak-version-support.md) as the single source of truth.
 
+!!! tip "Recovering from a complete failure?"
+    See the [Disaster Recovery](./disaster-recovery.md) guide for recovery order and what survives a database loss without a restore.
+
 ## Upgrade The Operator
 
 Helm is the primary upgrade path.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -4,6 +4,9 @@ This guide focuses on practical diagnosis of operator, Keycloak, realm, and clie
 
 Use Helm values and normal reconciliation flows as the primary fix path. Raw `kubectl patch` commands are useful as temporary diagnostics, not as the steady-state operating model.
 
+!!! tip "Recovering from a failure or data loss?"
+    See the [Disaster Recovery](./disaster-recovery.md) guide for recovery order, what you actually lose without a database restore, and common recovery scenarios.
+
 ## Quick Diagnostics
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Day Two Operations: operations/day-two.md
       - Secret Management: operations/secret-management.md
       - Backup & Restore: operations/backup-restore.md
+      - Disaster Recovery: operations/disaster-recovery.md
       - Troubleshooting: operations/troubleshooting.md
       - Migration & Upgrade: operations/migration.md
       - Escape Hatch: operations/escape-hatch.md


### PR DESCRIPTION
Closes #91

Adds a dedicated Disaster Recovery page to the Operations section of the documentation.

## What's included

- **Loss matrix** — what survives a database loss without a restore vs. what doesn't, framed positively (what you keep) with clear ❌ markers for real losses
- **Client secret recovery** — explains the DB as the authoritative source, the three cases (DB restored, DB wiped, manually bound), and the split between in-cluster pod restarts (Reloader/Kyverno) and out-of-cluster consumers (no automated path, ESO as the solution)
- **Recovery order** — database first, Keycloak second, operator reconciles automatically
- **Scenario table** — thin one-liners pointing to the right existing docs page for each common situation

## What's explicitly not included

- Database backup configuration (already in backup-restore.md)
- Velero/pg_dump procedures (not our job to document)
- Runbooks for scenarios already covered by migration.md, escape-hatch.md, troubleshooting.md (cross-linked instead)

## Related changes

- mkdocs.yml: `Disaster Recovery` added to the Operations nav between Backup & Restore and Troubleshooting
- troubleshooting.md and migration.md: tip callouts at the top redirecting DR traffic to the new page