### PR TITLE
fix(chart-operator+operator): derive keycloak tls verification from url

### DIFF
--- a/charts/keycloak-operator/README.md
+++ b/charts/keycloak-operator/README.md
@@ -211,6 +211,7 @@ These settings are not interchangeable:
 
 - `keycloak.admin.existingSecret` configures the managed `Keycloak` CR and is only used when `keycloak.managed=true`.
 - `keycloak.adminSecret` and `keycloak.adminPasswordKey` configure how the operator authenticates to Keycloak. They are required for `keycloak.managed=false` and default to the generated proxy secret in managed mode.
+- `keycloak.verifySsl` controls TLS certificate verification for HTTPS operator-to-Keycloak traffic. Leave it unset to auto-detect from `keycloak.url`: managed/internal HTTP defaults to no verification, external HTTPS defaults to verification.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
@@ -220,6 +221,7 @@ These settings are not interchangeable:
 | `keycloak.adminUsername` | Username the operator uses when authenticating to Keycloak | `admin` |
 | `keycloak.adminSecret` | Secret name the operator reads for the admin password | `""` |
 | `keycloak.adminPasswordKey` | Key in `keycloak.adminSecret` containing the admin password | `password` |
+| `keycloak.verifySsl` | Override TLS certificate verification for HTTPS Keycloak URLs; `null` auto-detects from the URL scheme | `null` |
 | `keycloak.admin.existingSecret` | Existing secret to seed admin credentials for a managed Keycloak instance | `""` |
 | `keycloak.replicas` | Number of Keycloak replicas | `1` |
 | `keycloak.version` | Keycloak version (image tag) | `"26.4.1"` |

--- a/charts/keycloak-operator/templates/03_operator_deployment.yaml
+++ b/charts/keycloak-operator/templates/03_operator_deployment.yaml
@@ -185,6 +185,10 @@ spec:
           value: {{ .Values.keycloak.adminUsername | quote }}
         - name: KEYCLOAK_ADMIN_PASSWORD_KEY
           value: {{ .Values.keycloak.adminPasswordKey | quote }}
+        {{- if ne .Values.keycloak.verifySsl nil }}
+        - name: KEYCLOAK_VERIFY_SSL
+          value: {{ .Values.keycloak.verifySsl | quote }}
+        {{- end }}
         # OpenTelemetry tracing configuration
         - name: OTEL_TRACING_ENABLED
           value: {{ .Values.operator.tracing.enabled | quote }}

--- a/charts/keycloak-operator/values.schema.json
+++ b/charts/keycloak-operator/values.schema.json
@@ -748,6 +748,14 @@
           "description": "Key in keycloak.adminSecret containing the password used by the operator to connect to Keycloak",
           "default": "password"
         },
+        "verifySsl": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether the operator verifies TLS certificates when connecting to Keycloak over HTTPS. Set to false for self-signed or otherwise non-verifiable certificates. Leave null to derive from the URL scheme: https defaults to true, http defaults to false.",
+          "default": null
+        },
         "replicas": {
           "type": "integer",
           "description": "Number of Keycloak replicas",

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -450,6 +450,10 @@ keycloak:
   adminSecret: ""
   # Key in the adminSecret containing the password used by the operator.
   adminPasswordKey: "password"
+  # Whether the operator verifies TLS certificates when connecting to Keycloak over HTTPS.
+  # Set to false for self-signed or otherwise non-verifiable certificates.
+  # Leave null to auto-detect from the URL scheme: https => true, http => false.
+  verifySsl: null
   # Managed Keycloak admin credential source.
   # When set, the operator copies username/password from this secret into the
   # generated <name>-admin-credentials proxy secret instead of generating new credentials.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -223,10 +223,11 @@ This is the highest-criticality boundary. Full admin credentials transit this ch
 **Threat**: Operator authenticates to a fake Keycloak instance and leaks admin credentials.
 
 **Controls**:
-- ✅ Keycloak is addressed by internal cluster DNS (`{name}.{namespace}.svc.cluster.local`) — not resolvable outside the cluster
-- ⚠️ **`verify_ssl` defaults to `False` in the admin client factory** — TLS certificate verification is disabled for all Keycloak connections. For managed (same-namespace) Keycloak, where HTTP is used internally, this is acceptable. For external Keycloak instances configured via `KEYCLOAK_URL`, this is a higher risk. **Tracked in issue #756.**
+- ✅ Operator-managed Keycloak is addressed by internal cluster DNS (`{name}.{namespace}.svc.cluster.local`) over in-cluster HTTP
+- ✅ External Keycloak connections derive TLS verification from `KEYCLOAK_URL`: `https://` defaults to certificate verification, `http://` defaults to no TLS verification
+- ✅ Operators can explicitly override TLS verification via `KEYCLOAK_VERIFY_SSL` / `keycloak.verifySsl`, which makes insecure external HTTPS an explicit configuration choice instead of an implicit default
 
-**Residual risk**: Medium for external Keycloak deployments until #756 is resolved. Low for operator-managed Keycloak (HTTP, same-namespace, not interceptable from outside the cluster).
+**Residual risk**: Low for operator-managed Keycloak (HTTP, same-namespace, not interceptable from outside the cluster). Low for external HTTPS when verification is left at the secure default. Medium only when external HTTPS deployments explicitly disable certificate verification for self-signed or non-standard PKI.
 
 ---
 
@@ -392,7 +393,7 @@ This is the highest-criticality boundary. Full admin credentials transit this ch
 | Operator → Keycloak over cluster-internal DNS | Not accessible from outside the cluster | ✅ In place |
 | Webhook TLS | cert-manager-issued certificate, automatic rotation | ✅ In place |
 | Network policies | Not shipped in Helm chart (ADR-076) | ⚠️ Platform responsibility |
-| TLS verification for Keycloak connections | Disabled by default in factory function | ❌ Gap — issue #756 |
+| TLS verification for Keycloak connections | Derived from URL scheme by default; explicit override available for self-signed or non-standard PKI | ✅ In place |
 
 ### Observability and Audit
 
@@ -471,17 +472,21 @@ spec:
 
 ---
 
-### GAP-3: TLS Verification Disabled for Keycloak Admin API
+### Accepted Risk-3: External HTTPS Deployments May Explicitly Disable TLS Verification
 
-**Severity**: Medium (external Keycloak) / Low (operator-managed Keycloak)
+**Severity**: Medium when explicitly configured / Low by default
 
-The `get_keycloak_admin_client()` factory defaults to `verify_ssl=False`, disabling certificate verification for the operator→Keycloak admin API connection. Admin credentials transit this channel.
+The operator now derives TLS verification from `KEYCLOAK_URL`: `https://` verifies certificates by default and `http://` does not. This closes the previous unsafe default described in issue #756.
 
-**For operator-managed Keycloak**: HTTP is used on `svc.cluster.local` — TLS verification is not meaningful. Risk is low (traffic does not leave the cluster network).
+**For operator-managed Keycloak**: HTTP is used on `svc.cluster.local` — TLS verification is not meaningful. Risk remains low because traffic stays on the cluster network.
 
-**For external Keycloak (`KEYCLOAK_URL` configured)**: This is a genuine MITM risk if the connection passes through a load balancer or service mesh where interception is possible.
+**For external Keycloak (`KEYCLOAK_URL` configured)**: HTTPS is now verified by default. The remaining risk appears only when an operator explicitly sets `KEYCLOAK_VERIFY_SSL=false` / `keycloak.verifySsl=false` to tolerate self-signed or otherwise non-verifiable certificates.
 
-**Tracked**: Issue #756. Fix will enforce TLS verification for external Keycloak and make the behavior explicit via a setting.
+**Accepted because**: Some environments still rely on self-signed or private PKI chains that are not trusted by the operator runtime, so a documented escape hatch is required.
+
+**Mitigations in place**: Secure default for external HTTPS, scheme-derived behavior for managed in-cluster HTTP, explicit Helm/env configuration for the override, and startup warning when HTTPS verification is disabled.
+
+**What would reduce risk further**: Mount a trusted CA bundle into the operator and keep `KEYCLOAK_VERIFY_SSL=true` for all HTTPS deployments.
 
 ---
 
@@ -629,5 +634,5 @@ Add an additional egress rule for your OTLP collector if tracing is enabled.
 - [OWASP Kubernetes Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html)
 - [NIST SP 800-190](https://csrc.nist.gov/publications/detail/sp/800/190/final) — Application Container Security Guide
 - GitHub issue #94 — original threat model tracking issue
-- GitHub issue #756 — TLS verification fix
+- GitHub issue #756 — resolved TLS verification fix
 - GitHub issue #760 — drift detection alerting and credential rotation

--- a/src/keycloak_operator/operator.py
+++ b/src/keycloak_operator/operator.py
@@ -98,8 +98,22 @@ def log_keycloak_connection_security_configuration() -> None:
         logging.warning(
             "TLS certificate verification for the Keycloak admin API is disabled for HTTPS URL %s. "
             "Use this only with explicitly trusted self-signed certificates or non-standard PKI.",
-            operator_settings.keycloak_url,
+            _sanitize_url_for_log(operator_settings.keycloak_url),
         )
+
+
+def _sanitize_url_for_log(url: str) -> str:
+    """Remove credentials from URLs before emitting them to logs."""
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        return "<invalid-url>"
+
+    hostname = parsed.hostname or "<unknown-host>"
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+
+    port_suffix = f":{parsed.port}" if parsed.port is not None else ""
+    return f"{parsed.scheme}://{hostname}{port_suffix}"
 
 
 @kopf.on.startup()

--- a/src/keycloak_operator/operator.py
+++ b/src/keycloak_operator/operator.py
@@ -22,6 +22,7 @@ Environment Variables:
 import logging
 import random
 import sys
+from urllib.parse import urlparse
 
 import kopf
 from kubernetes import config
@@ -85,6 +86,22 @@ def get_watched_namespaces() -> list[str] | None:
     return operator_settings.watched_namespaces
 
 
+def log_keycloak_connection_security_configuration() -> None:
+    """Log warnings for insecure HTTPS operator-to-Keycloak connections."""
+    if not operator_settings.keycloak_url:
+        return
+
+    if urlparse(operator_settings.keycloak_url).scheme.lower() != "https":
+        return
+
+    if not operator_settings.resolved_keycloak_verify_ssl:
+        logging.warning(
+            "TLS certificate verification for the Keycloak admin API is disabled for HTTPS URL %s. "
+            "Use this only with explicitly trusted self-signed certificates or non-standard PKI.",
+            operator_settings.keycloak_url,
+        )
+
+
 @kopf.on.startup()
 async def startup_handler(
     settings: kopf.OperatorSettings, memo: kopf.Memo, **_
@@ -144,6 +161,8 @@ async def startup_handler(
     dry_run = operator_settings.dry_run
     if dry_run:
         logging.info("Running in DRY-RUN mode - no changes will be applied")
+
+    log_keycloak_connection_security_configuration()
 
     # Load Kubernetes configuration if not already loaded
     try:

--- a/src/keycloak_operator/settings.py
+++ b/src/keycloak_operator/settings.py
@@ -452,7 +452,12 @@ class Settings(BaseSettings):
         if not self.keycloak_url:
             return True
 
-        return urlparse(self.keycloak_url).scheme.lower() == "https"
+        scheme = urlparse(self.keycloak_url).scheme.lower()
+        if scheme == "http":
+            return False
+        if scheme == "https":
+            return True
+        return True
 
 
 # Global settings instance - initialized once at module import

--- a/src/keycloak_operator/settings.py
+++ b/src/keycloak_operator/settings.py
@@ -5,6 +5,8 @@ loaded from environment variables. Uses pydantic for automatic validation,
 type coercion, and documentation.
 """
 
+from urllib.parse import urlparse
+
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -128,6 +130,13 @@ class Settings(BaseSettings):
         default=True,
         validation_alias="KEYCLOAK_MANAGED",
         description="Whether the operator is allowed to manage Keycloak CRs.",
+    )
+    keycloak_verify_ssl: bool | None = Field(
+        default=None,
+        validation_alias="KEYCLOAK_VERIFY_SSL",
+        description="Whether to verify TLS certificates for HTTPS Keycloak admin API connections. "
+        "When unset, the operator derives the behavior from KEYCLOAK_URL: HTTPS defaults to true, "
+        "HTTP defaults to false.",
     )
 
     # Logging configuration
@@ -433,6 +442,17 @@ class Settings(BaseSettings):
         if self.namespaces:
             return [ns.strip() for ns in self.namespaces.split(",") if ns.strip()]
         return None
+
+    @property
+    def resolved_keycloak_verify_ssl(self) -> bool:
+        """Resolve Keycloak SSL verification from explicit config or URL scheme."""
+        if self.keycloak_verify_ssl is not None:
+            return self.keycloak_verify_ssl
+
+        if not self.keycloak_url:
+            return True
+
+        return urlparse(self.keycloak_url).scheme.lower() == "https"
 
 
 # Global settings instance - initialized once at module import

--- a/src/keycloak_operator/utils/keycloak_admin.py
+++ b/src/keycloak_operator/utils/keycloak_admin.py
@@ -7927,7 +7927,7 @@ async def get_keycloak_admin_client(
     keycloak_name: str,
     namespace: str,
     rate_limiter: "RateLimiter | None" = None,
-    verify_ssl: bool = False,
+    verify_ssl: bool | None = None,
 ) -> KeycloakAdminClient:
     """
     Get or create a cached KeycloakAdminClient for the globally configured Keycloak instance.
@@ -7936,13 +7936,18 @@ async def get_keycloak_admin_client(
         keycloak_name: Name of the Keycloak instance (ignored in agnostic mode)
         namespace: Namespace where the Keycloak instance exists (ignored in agnostic mode)
         rate_limiter: Optional rate limiter for API throttling
-        verify_ssl: Whether to verify SSL certificates (default: False)
+        verify_ssl: Whether to verify SSL certificates. When unset, derived from
+            operator settings and the KEYCLOAK_URL scheme.
 
     Returns:
         Configured KeycloakAdminClient instance (may be cached)
     """
+    resolved_verify_ssl = (
+        settings.resolved_keycloak_verify_ssl if verify_ssl is None else verify_ssl
+    )
+
     # In agnostic mode, we always use the single globally configured instance
-    cache_key = ("__global__", "", verify_ssl)
+    cache_key = ("__global__", "", resolved_verify_ssl)
 
     current_loop_id = id(asyncio.get_running_loop())
 
@@ -8029,7 +8034,7 @@ async def get_keycloak_admin_client(
             server_url=server_url,
             username=username,
             password=password,
-            verify_ssl=verify_ssl,
+            verify_ssl=resolved_verify_ssl,
             rate_limiter=rate_limiter,
             keycloak_name="global",
             keycloak_namespace=settings.pod_namespace,

--- a/tests/unit/test_external_keycloak.py
+++ b/tests/unit/test_external_keycloak.py
@@ -24,6 +24,29 @@ def test_external_keycloak_settings():
     assert settings.keycloak_url == "https://external.keycloak"
     assert settings.keycloak_admin_secret == "ext-secret"
     assert settings.keycloak_admin_username == "admin"
+    assert settings.keycloak_verify_ssl is None
+    assert settings.resolved_keycloak_verify_ssl is True
+
+
+def test_external_keycloak_settings_verify_ssl_override_false():
+    settings = Settings(
+        KEYCLOAK_URL="https://external.keycloak",
+        KEYCLOAK_ADMIN_SECRET="ext-secret",
+        KEYCLOAK_VERIFY_SSL=False,
+    )
+
+    assert settings.keycloak_verify_ssl is False
+    assert settings.resolved_keycloak_verify_ssl is False
+
+
+def test_internal_http_keycloak_settings_disable_ssl_verification_automatically():
+    settings = Settings(
+        KEYCLOAK_URL="http://keycloak.operator-ns.svc.cluster.local:8080",
+        KEYCLOAK_ADMIN_SECRET="ext-secret",
+    )
+
+    assert settings.keycloak_verify_ssl is None
+    assert settings.resolved_keycloak_verify_ssl is False
 
 
 # Test validate_keycloak_reference
@@ -61,6 +84,7 @@ async def test_get_keycloak_admin_client_external(
     mock_settings.pod_namespace = "operator-ns"
     mock_settings.keycloak_admin_username = "admin"
     mock_settings.keycloak_admin_password_key = "password"
+    mock_settings.resolved_keycloak_verify_ssl = True
 
     mock_core = MagicMock()
     mock_k8s_client = MagicMock()
@@ -89,6 +113,56 @@ async def test_get_keycloak_admin_client_external(
         )
 
         # Verify client creation
+        mock_cls.assert_called_with(
+            server_url="https://external.keycloak",
+            username="admin",
+            password="secret-pass",
+            verify_ssl=True,
+            rate_limiter=None,
+            keycloak_name="global",
+            keycloak_namespace="operator-ns",
+        )
+
+
+@pytest.mark.asyncio
+@patch("keycloak_operator.utils.keycloak_admin.settings")
+@patch("keycloak_operator.utils.kubernetes.get_kubernetes_client")
+@patch("keycloak_operator.utils.keycloak_admin.KeycloakAdminClient")
+@patch("keycloak_operator.utils.keycloak_admin._cache_lock", new_callable=MagicMock)
+@patch("keycloak_operator.utils.keycloak_admin._admin_client_cache", {})
+@patch("keycloak_operator.utils.keycloak_admin._pending_creations", {})
+async def test_get_keycloak_admin_client_external_honors_insecure_override(
+    mock_cache_lock, mock_cls, mock_get_k8s, mock_settings
+):
+    mock_lock_instance = MagicMock()
+    mock_lock_instance.__aenter__.return_value = None
+    mock_lock_instance.__aexit__.return_value = None
+    mock_cache_lock.return_value = mock_lock_instance
+
+    mock_settings.keycloak_url = "https://external.keycloak"
+    mock_settings.keycloak_admin_secret = "ext-secret"
+    mock_settings.pod_namespace = "operator-ns"
+    mock_settings.keycloak_admin_username = "admin"
+    mock_settings.keycloak_admin_password_key = "password"
+    mock_settings.resolved_keycloak_verify_ssl = False
+
+    mock_core = MagicMock()
+    mock_k8s_client = MagicMock()
+    mock_get_k8s.return_value = mock_k8s_client
+
+    mock_instance = MagicMock()
+    future = asyncio.Future()
+    future.set_result(None)
+    mock_instance.authenticate.return_value = future
+    mock_cls.return_value = mock_instance
+
+    with patch("kubernetes.client.CoreV1Api", return_value=mock_core):
+        mock_secret = MagicMock()
+        mock_secret.data = {"password": base64.b64encode(b"secret-pass").decode()}
+        mock_core.read_namespaced_secret.return_value = mock_secret
+
+        _ = await get_keycloak_admin_client("my-kc", "default")
+
         mock_cls.assert_called_with(
             server_url="https://external.keycloak",
             username="admin",

--- a/tests/unit/test_external_keycloak.py
+++ b/tests/unit/test_external_keycloak.py
@@ -49,6 +49,16 @@ def test_internal_http_keycloak_settings_disable_ssl_verification_automatically(
     assert settings.resolved_keycloak_verify_ssl is False
 
 
+def test_invalid_keycloak_url_scheme_defaults_to_ssl_verification():
+    settings = Settings(
+        KEYCLOAK_URL="ftp://external.keycloak",
+        KEYCLOAK_ADMIN_SECRET="ext-secret",
+    )
+
+    assert settings.keycloak_verify_ssl is None
+    assert settings.resolved_keycloak_verify_ssl is True
+
+
 # Test validate_keycloak_reference
 @patch("keycloak_operator.utils.kubernetes.settings")
 def test_validate_keycloak_reference_external(mock_settings):

--- a/tests/unit/test_operator_keycloak_ssl_logging.py
+++ b/tests/unit/test_operator_keycloak_ssl_logging.py
@@ -8,12 +8,18 @@ from keycloak_operator.operator import log_keycloak_connection_security_configur
 def test_logs_warning_for_insecure_https_keycloak_connection(
     mock_settings, mock_warning
 ):
-    mock_settings.keycloak_url = "https://external.keycloak"
+    mock_settings.keycloak_url = (
+        "https://admin:super-secret@external.keycloak:8443/auth"
+    )
     mock_settings.resolved_keycloak_verify_ssl = False
 
     log_keycloak_connection_security_configuration()
 
-    mock_warning.assert_called_once()
+    mock_warning.assert_called_once_with(
+        "TLS certificate verification for the Keycloak admin API is disabled for HTTPS URL %s. "
+        "Use this only with explicitly trusted self-signed certificates or non-standard PKI.",
+        "https://external.keycloak:8443",
+    )
 
 
 @patch("keycloak_operator.operator.logging.warning")

--- a/tests/unit/test_operator_keycloak_ssl_logging.py
+++ b/tests/unit/test_operator_keycloak_ssl_logging.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+from keycloak_operator.operator import log_keycloak_connection_security_configuration
+
+
+@patch("keycloak_operator.operator.logging.warning")
+@patch("keycloak_operator.operator.operator_settings")
+def test_logs_warning_for_insecure_https_keycloak_connection(
+    mock_settings, mock_warning
+):
+    mock_settings.keycloak_url = "https://external.keycloak"
+    mock_settings.resolved_keycloak_verify_ssl = False
+
+    log_keycloak_connection_security_configuration()
+
+    mock_warning.assert_called_once()
+
+
+@patch("keycloak_operator.operator.logging.warning")
+@patch("keycloak_operator.operator.operator_settings")
+def test_does_not_log_warning_for_internal_http_keycloak_connection(
+    mock_settings, mock_warning
+):
+    mock_settings.keycloak_url = "http://keycloak.operator-ns.svc.cluster.local:8080"
+    mock_settings.resolved_keycloak_verify_ssl = False
+
+    log_keycloak_connection_security_configuration()
+
+    mock_warning.assert_not_called()
+
+
+@patch("keycloak_operator.operator.logging.warning")
+@patch("keycloak_operator.operator.operator_settings")
+def test_does_not_log_warning_for_verified_https_keycloak_connection(
+    mock_settings, mock_warning
+):
+    mock_settings.keycloak_url = "https://external.keycloak"
+    mock_settings.resolved_keycloak_verify_ssl = True
+
+    log_keycloak_connection_security_configuration()
+
+    mock_warning.assert_not_called()


### PR DESCRIPTION
## Summary
- derive Keycloak TLS verification from the configured URL scheme by default
- expose an explicit Helm/env override for HTTPS certificate verification
- warn only when HTTPS verification is disabled and cover the behavior with tests

Closes #756

## Validation
- task test:unit
- task test:coverage-check
- task test:all