### PR TITLE
fix: prevent client secret RBAC failures from crashing the operator

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -109,7 +109,7 @@ tasks:
     desc: Run security scans (pip-audit, safety, trivy)
     cmds:
       - uv export --no-dev --format requirements-txt | grep -v '^\-e' | uv run --group security pip-audit -r /dev/stdin --desc
-      - uv run --group security safety check --json
+      - uv export --no-dev --format requirements-txt | grep -v '^\-e' | uv run --group security safety check --stdin --json
       - |
         if [ -z "$CI" ] && command -v trivy >/dev/null 2>&1; then
           echo "🔍 Running Trivy image scan..."

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -53,8 +53,9 @@ ENV PATH=/app/.venv/bin:$PATH \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
-# Install runtime system dependencies
-RUN apk add --no-cache \
+# Install runtime system dependencies and apply latest Alpine security fixes
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
     ca-certificates
     # libstdc++ is often required by binary python extensions
     # libstdc++
@@ -108,9 +109,6 @@ FROM production AS test
 
 # Switch to root to install test dependencies
 USER root
-
-# Install build dependencies for test packages (just in case test deps need compilation)
-RUN apk add --no-cache build-base
 
 # Copy uv for installing test dependencies
 COPY --from=ghcr.io/astral-sh/uv:0.9.3@sha256:ecfea7316b266ba82a5e9efb052339ca410dd774dc01e134a30890e6b85c7cd1 /uv /bin/uv

--- a/src/keycloak_operator/handlers/client.py
+++ b/src/keycloak_operator/handlers/client.py
@@ -60,7 +60,7 @@ from keycloak_operator.utils.pause import get_pause_message, is_clients_paused
 logger = logging.getLogger(__name__)
 
 
-CLIENT_SECRET_MONITOR_INTERVAL_SECONDS = 30.0
+CLIENT_SECRET_MONITOR_INTERVAL_SECONDS = TIMER_INTERVAL_CLIENT
 
 
 def is_matching_namespace(spec: dict[str, Any], namespace: str, **_: Any) -> bool:
@@ -804,14 +804,17 @@ async def _run_client_health_check(
                             logger=logger,
                         )
 
-                        if triggered:
-                            patch.status.update(
-                                {
-                                    "phase": "Degraded",
-                                    "message": "Client credentials secret missing, recreating...",
-                                    "lastHealthCheck": datetime.now(UTC).isoformat(),
-                                }
-                            )
+                        patch.status.update(
+                            {
+                                "phase": "Degraded",
+                                "message": (
+                                    "Client credentials secret missing, recreating..."
+                                    if triggered
+                                    else "Client credentials secret missing, but reconcile trigger failed"
+                                ),
+                                "lastHealthCheck": datetime.now(UTC).isoformat(),
+                            }
+                        )
                         return
                     if e.status == 403:
                         logger.warning(
@@ -915,6 +918,7 @@ async def monitor_client_credentials_secret(
                     {
                         "phase": "Degraded",
                         "message": "Client credentials secret incomplete, recreating...",
+                        "lastHealthCheck": datetime.now(UTC).isoformat(),
                     }
                 )
                 await _trigger_client_reconciliation(
@@ -932,6 +936,7 @@ async def monitor_client_credentials_secret(
                     {
                         "phase": "Degraded",
                         "message": "Client credentials secret missing, recreating...",
+                        "lastHealthCheck": datetime.now(UTC).isoformat(),
                     }
                 )
                 await _trigger_client_reconciliation(
@@ -952,6 +957,7 @@ async def monitor_client_credentials_secret(
                             "Operator lacks permission to read client credentials secret. "
                             "Grant delegated RBAC for this namespace."
                         ),
+                        "lastHealthCheck": datetime.now(UTC).isoformat(),
                     }
                 )
             else:
@@ -1185,6 +1191,7 @@ async def secret_rotation_daemon(
                         "Operator lacks permission to read client credentials secret. "
                         "Grant delegated RBAC for this namespace."
                     )
+                    patch.status["lastHealthCheck"] = datetime.now(UTC).isoformat()
                     if await stopped.wait(timeout=60):
                         break
                     continue

--- a/src/keycloak_operator/handlers/client.py
+++ b/src/keycloak_operator/handlers/client.py
@@ -60,6 +60,9 @@ from keycloak_operator.utils.pause import get_pause_message, is_clients_paused
 logger = logging.getLogger(__name__)
 
 
+CLIENT_SECRET_MONITOR_INTERVAL_SECONDS = 30.0
+
+
 def is_matching_namespace(spec: dict[str, Any], namespace: str, **_: Any) -> bool:
     """
     Check if the resource is targeted at this operator instance (ADR-062).
@@ -110,6 +113,59 @@ class StatusWrapper:
         """Update multiple fields. Assumes data keys are already in camelCase."""
         for k, v in data.items():
             self._patch_status[k] = v
+
+
+async def _trigger_client_reconciliation(
+    *,
+    name: str,
+    namespace: str,
+    reason: str,
+    logger: logging.Logger,
+) -> bool:
+    """Patch the client resource to trigger reconciliation.
+
+    Returns True when the patch request was accepted, False when the parent CR
+    no longer exists or the request could not be completed.
+    """
+    api = client.CustomObjectsApi(get_kubernetes_client())
+    patch_body = {
+        "metadata": {
+            "annotations": {
+                ANNOTATION_RECONCILE_FORCE: f"{reason}-{datetime.now(UTC).timestamp()}"
+            }
+        }
+    }
+
+    try:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: api.patch_namespaced_custom_object(
+                group="vriesdemichael.github.io",
+                version="v1",
+                namespace=namespace,
+                plural="keycloakclients",
+                name=name,
+                body=patch_body,
+            ),
+        )
+        return True
+    except ApiException as e:
+        if e.status == 404:
+            logger.warning(
+                f"Parent KeycloakClient {name} not found, skipping reconcile trigger"
+            )
+            return False
+        logger.error(f"Failed to trigger reconciliation for KeycloakClient {name}: {e}")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error triggering reconciliation for {name}: {e}")
+        return False
+
+
+def _should_monitor_client_secret(spec: dict[str, Any], **_: Any) -> bool:
+    """Run the secret monitor only for managed confidential clients."""
+    return not spec.get("publicClient", False) and spec.get("manageSecret", True)
 
 
 async def _perform_client_cleanup(
@@ -741,34 +797,34 @@ async def _run_client_health_check(
                             "Client credentials secret missing, triggering reconciliation to recreate it"
                         )
 
-                        # Trigger reconciliation by updating an annotation
-                        custom_api = client.CustomObjectsApi(k8s_client)
-                        patch_body = {
-                            "metadata": {
-                                "annotations": {
-                                    ANNOTATION_RECONCILE_FORCE: f"secret-missing-{datetime.now(UTC).timestamp()}"
-                                }
-                            }
-                        }
-
-                        # Use run_in_executor to avoid blocking
-                        loop = asyncio.get_running_loop()
-                        await loop.run_in_executor(
-                            None,
-                            lambda: custom_api.patch_namespaced_custom_object(
-                                group="vriesdemichael.github.io",
-                                version="v1",
-                                namespace=namespace,
-                                plural="keycloakclients",
-                                name=name,
-                                body=patch_body,
-                            ),
+                        triggered = await _trigger_client_reconciliation(
+                            name=name,
+                            namespace=namespace,
+                            reason="secret-missing",
+                            logger=logger,
                         )
 
+                        if triggered:
+                            patch.status.update(
+                                {
+                                    "phase": "Degraded",
+                                    "message": "Client credentials secret missing, recreating...",
+                                    "lastHealthCheck": datetime.now(UTC).isoformat(),
+                                }
+                            )
+                        return
+                    if e.status == 403:
+                        logger.warning(
+                            "Operator lacks permission to read client credentials secret "
+                            f"{secret_name} in namespace {namespace}"
+                        )
                         patch.status.update(
                             {
                                 "phase": "Degraded",
-                                "message": "Client credentials secret missing, recreating...",
+                                "message": (
+                                    "Operator lacks permission to read client credentials secret. "
+                                    "Grant delegated RBAC for this namespace."
+                                ),
                                 "lastHealthCheck": datetime.now(UTC).isoformat(),
                             }
                         )
@@ -802,76 +858,113 @@ async def _run_client_health_check(
         )
 
 
-@kopf.on.event(
-    "secrets", labels={"vriesdemichael.github.io/keycloak-client": kopf.PRESENT}
+@kopf.daemon(
+    "keycloakclients",
+    when=_should_monitor_client_secret,
+    cancellation_timeout=10.0,
 )
-async def monitor_client_secrets(
-    event: dict[str, Any],
+async def monitor_client_credentials_secret(
+    spec: dict[str, Any],
+    name: str,
+    namespace: str,
+    status: dict[str, Any],
+    meta: dict[str, Any],
+    stopped: kopf.DaemonStopped,
+    patch: kopf.Patch,
     logger: logging.Logger,
     **kwargs: Any,
 ) -> None:
-    """
-    Monitor client secrets and trigger reconciliation if deleted.
+    """Monitor a managed client credentials secret within the client's namespace.
 
-    If a managed secret is deleted, we must trigger reconciliation on the
-    parent KeycloakClient to recreate it.
+    This replaces the old cluster-wide secret watch with a per-client daemon so
+    the operator never needs to open a cluster-wide secret watch stream.
     """
-    # Only react to deletion events
-    if event["type"] != "DELETED":
+    if not await is_client_managed_by_this_operator(
+        spec, namespace, get_kubernetes_client()
+    ):
         return
 
-    meta = event["object"]["metadata"]
-    name = meta["name"]
-    namespace = meta["namespace"]
-    labels = meta.get("labels", {})
-    client_name = labels.get("vriesdemichael.github.io/keycloak-client")
+    secret_name = f"{name}-credentials"
+    k8s_client = get_kubernetes_client()
+    core_api = client.CoreV1Api(k8s_client)
 
-    if not client_name:
-        return
+    while not stopped:
+        if meta.get("deletionTimestamp"):
+            return
 
-    logger.info(
-        f"Managed secret {name} deleted, triggering reconciliation for KeycloakClient {client_name}"
-    )
+        if is_clients_paused():
+            logger.debug(
+                f"Secret monitor paused for client {name}: reconciliation paused"
+            )
+            if await stopped.wait(timeout=60):
+                break
+            continue
 
-    # Touch the KeycloakClient to trigger reconciliation
-    try:
-        api = client.CustomObjectsApi(get_kubernetes_client())
-
-        # We need to use a distinct annotation value to ensure a change event
-        patch_body = {
-            "metadata": {
-                "annotations": {
-                    ANNOTATION_RECONCILE_FORCE: f"secret-deleted-{datetime.now(UTC).timestamp()}"
-                }
-            }
-        }
-
-        # Use run_in_executor to avoid blocking the event loop with synchronous K8s calls
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None,
-            lambda: api.patch_namespaced_custom_object(
-                group="vriesdemichael.github.io",
-                version="v1",
-                namespace=namespace,
-                plural="keycloakclients",
-                name=client_name,
-                body=patch_body,
-            ),
-        )
-        logger.info(f"Triggered reconciliation for KeycloakClient {client_name}")
-
-    except ApiException as e:
-        if e.status == 404:
+        try:
+            secret = await asyncio.to_thread(
+                core_api.read_namespaced_secret,
+                secret_name,
+                namespace,
+            )
+            if (
+                not secret.data
+                or "client-id" not in secret.data
+                or "client-secret" not in secret.data
+            ):
+                patch.status.update(
+                    {
+                        "phase": "Degraded",
+                        "message": "Client credentials secret incomplete, recreating...",
+                    }
+                )
+                await _trigger_client_reconciliation(
+                    name=name,
+                    namespace=namespace,
+                    reason="secret-invalid",
+                    logger=logger,
+                )
+        except ApiException as e:
+            if e.status == 404:
+                logger.info(
+                    f"Managed secret {secret_name} missing for KeycloakClient {name}, triggering reconciliation"
+                )
+                patch.status.update(
+                    {
+                        "phase": "Degraded",
+                        "message": "Client credentials secret missing, recreating...",
+                    }
+                )
+                await _trigger_client_reconciliation(
+                    name=name,
+                    namespace=namespace,
+                    reason="secret-missing",
+                    logger=logger,
+                )
+            elif e.status == 403:
+                logger.warning(
+                    "Operator lacks permission to read managed client credentials secret "
+                    f"{secret_name} in namespace {namespace}"
+                )
+                patch.status.update(
+                    {
+                        "phase": "Degraded",
+                        "message": (
+                            "Operator lacks permission to read client credentials secret. "
+                            "Grant delegated RBAC for this namespace."
+                        ),
+                    }
+                )
+            else:
+                logger.warning(
+                    f"Failed to monitor client credentials secret {secret_name}: {e}"
+                )
+        except Exception as e:
             logger.warning(
-                f"Parent KeycloakClient {client_name} not found, ignoring secret deletion"
+                f"Unexpected error while monitoring client credentials secret {secret_name}: {e}"
             )
-        else:
-            logger.error(
-                f"Failed to trigger reconciliation for KeycloakClient {client_name}: {e}"
-            )
-    except Exception as e:
-        logger.error(f"Unexpected error triggering reconciliation: {e}")
+
+        if await stopped.wait(timeout=CLIENT_SECRET_MONITOR_INTERVAL_SECONDS):
+            break
 
 
 # Constants for rotation daemon
@@ -1080,6 +1173,19 @@ async def secret_rotation_daemon(
                     )
                     # Wait a bit and retry - secret may not be created yet
                     if await stopped.wait(timeout=30):
+                        break
+                    continue
+                if e.status == 403:
+                    logger.warning(
+                        "Operator lacks permission to read client credentials secret "
+                        f"{secret_name} in namespace {namespace}; rotation paused"
+                    )
+                    patch.status["phase"] = "Degraded"
+                    patch.status["message"] = (
+                        "Operator lacks permission to read client credentials secret. "
+                        "Grant delegated RBAC for this namespace."
+                    )
+                    if await stopped.wait(timeout=60):
                         break
                     continue
                 raise

--- a/tests/integration/test_client_secret_lifecycle.py
+++ b/tests/integration/test_client_secret_lifecycle.py
@@ -10,10 +10,12 @@ Tests verify:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import uuid
 
 import pytest
+from kubernetes import client
 from kubernetes.client.rest import ApiException
 
 from .wait_helpers import (
@@ -188,3 +190,145 @@ class TestClientSecretLifecycle:
         assert secret.metadata.owner_references[0].name == client_name
 
         logger.info("✓ Successfully verified client secret lifecycle")
+
+    @pytest.mark.timeout(420)
+    async def test_secret_monitor_survives_missing_namespace_rbac(
+        self,
+        k8s_custom_objects,
+        k8s_core_v1,
+        k8s_rbac_v1,
+        test_namespace: str,
+        operator_namespace: str,
+        shared_operator,
+        helm_realm,
+        helm_client,
+    ) -> None:
+        """Deleting delegated RBAC must not crash the operator secret monitor."""
+        suffix = uuid.uuid4().hex[:8]
+        realm_name = f"rbac-realm-{suffix}"
+        client_name = f"rbac-client-{suffix}"
+        realm_release_name = f"realm-rbac-{suffix}"
+        client_release_name = f"client-rbac-{suffix}"
+        namespace = test_namespace
+        secret_name = f"{client_name}-credentials"
+
+        await helm_realm(
+            release_name=realm_release_name,
+            realm_name=realm_name,
+            namespace=namespace,
+            operator_namespace=operator_namespace,
+            clientAuthorizationGrants=[namespace],
+            displayName="RBAC Resilience Realm",
+            fullnameOverride=realm_name,
+        )
+
+        await wait_for_resource_ready(
+            k8s_custom_objects=k8s_custom_objects,
+            group="vriesdemichael.github.io",
+            version="v1",
+            namespace=namespace,
+            plural="keycloakrealms",
+            name=realm_name,
+            timeout=120,
+            operator_namespace=operator_namespace,
+        )
+
+        await helm_client(
+            release_name=client_release_name,
+            client_id=client_name,
+            realm_name=realm_name,
+            realm_namespace=namespace,
+            publicClient=False,
+            manageSecret=True,
+            fullnameOverride=client_name,
+        )
+
+        await wait_for_resource_ready(
+            k8s_custom_objects=k8s_custom_objects,
+            group="vriesdemichael.github.io",
+            version="v1",
+            namespace=namespace,
+            plural="keycloakclients",
+            name=client_name,
+            timeout=120,
+            operator_namespace=operator_namespace,
+        )
+
+        await wait_for_secret_keys(
+            k8s_core_v1=k8s_core_v1,
+            secret_name=secret_name,
+            namespace=namespace,
+            required_keys=["client-secret", "client-id"],
+            timeout=60,
+            operator_namespace=operator_namespace,
+        )
+
+        for role_binding_name in (
+            "keycloak-operator-access",
+            f"{realm_name}-operator-access",
+            f"{client_name}-operator-access",
+        ):
+            try:
+                await k8s_rbac_v1.delete_namespaced_role_binding(
+                    name=role_binding_name,
+                    namespace=namespace,
+                )
+            except ApiException as e:
+                if e.status != 404:
+                    raise
+
+        await k8s_core_v1.delete_namespaced_secret(secret_name, namespace)
+
+        start = asyncio.get_running_loop().time()
+        while asyncio.get_running_loop().time() - start < 90:
+            with contextlib.suppress(ApiException):
+                await k8s_core_v1.read_namespaced_secret(secret_name, namespace)
+                pytest.fail(
+                    "Managed secret was recreated even though delegated RBAC was removed"
+                )
+
+            pods = await k8s_core_v1.list_namespaced_pod(
+                namespace=operator_namespace,
+                label_selector="app.kubernetes.io/name=keycloak-operator",
+            )
+            assert pods.items, "No operator pods found"
+            for pod in pods.items:
+                assert pod.status.phase == "Running", (
+                    f"Operator pod {pod.metadata.name} is not running"
+                )
+                if pod.status.container_statuses:
+                    for container_status in pod.status.container_statuses:
+                        assert container_status.ready, (
+                            f"Operator container {container_status.name} is not ready"
+                        )
+
+            await asyncio.sleep(5)
+
+        role_binding = client.V1RoleBinding(
+            metadata=client.V1ObjectMeta(
+                name="keycloak-operator-access",
+                namespace=namespace,
+            ),
+            role_ref=client.V1RoleRef(
+                api_group="rbac.authorization.k8s.io",
+                kind="ClusterRole",
+                name="keycloak-operator-namespace-access",
+            ),
+            subjects=[
+                client.RbacV1Subject(
+                    kind="ServiceAccount",
+                    name=f"keycloak-operator-{operator_namespace}",
+                    namespace=operator_namespace,
+                )
+            ],
+        )
+        await k8s_rbac_v1.create_namespaced_role_binding(namespace, role_binding)
+
+        await wait_for_secret_keys(
+            k8s_core_v1=k8s_core_v1,
+            secret_name=secret_name,
+            namespace=namespace,
+            required_keys=["client-secret", "client-id"],
+            timeout=120,
+            operator_namespace=operator_namespace,
+        )

--- a/tests/integration/test_client_secret_lifecycle.py
+++ b/tests/integration/test_client_secret_lifecycle.py
@@ -10,7 +10,6 @@ Tests verify:
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import uuid
 
@@ -281,11 +280,14 @@ class TestClientSecretLifecycle:
 
         start = asyncio.get_running_loop().time()
         while asyncio.get_running_loop().time() - start < 90:
-            with contextlib.suppress(ApiException):
+            try:
                 await k8s_core_v1.read_namespaced_secret(secret_name, namespace)
                 pytest.fail(
                     "Managed secret was recreated even though delegated RBAC was removed"
                 )
+            except ApiException as e:
+                if e.status != 404:
+                    raise
 
             pods = await k8s_core_v1.list_namespaced_pod(
                 namespace=operator_namespace,

--- a/tests/unit/test_client_secret_rotation.py
+++ b/tests/unit/test_client_secret_rotation.py
@@ -238,3 +238,48 @@ class TestSecretRotationDaemon:
 
             # Verify status was updated
             assert mock_patch_obj.status.get("phase") == "Ready"
+
+    @pytest.mark.asyncio
+    async def test_daemon_secret_forbidden_degrades_without_crashing(
+        self, mock_stopped, mock_patch_obj, base_spec
+    ):
+        """403 on secret read should degrade and wait instead of crashing the daemon."""
+        from kubernetes.client.rest import ApiException
+
+        from keycloak_operator.handlers.client import secret_rotation_daemon
+
+        mock_core_api = MagicMock()
+        mock_core_api.read_namespaced_secret.side_effect = ApiException(status=403)
+
+        with (
+            patch(
+                "keycloak_operator.handlers.client.get_kubernetes_client"
+            ) as mock_get_k8s,
+            patch(
+                "keycloak_operator.handlers.client.client.CoreV1Api"
+            ) as mock_core_api_cls,
+            patch(
+                "keycloak_operator.handlers.client.is_client_managed_by_this_operator",
+                return_value=True,
+            ),
+        ):
+            mock_get_k8s.return_value = MagicMock()
+            mock_core_api_cls.return_value = mock_core_api
+
+            mock_stopped.wait = AsyncMock(return_value=True)
+            mock_stopped.__bool__ = MagicMock(return_value=False)
+
+            await secret_rotation_daemon(
+                spec=base_spec,
+                name="test-client",
+                namespace="test-ns",
+                status={},
+                meta={"uid": "test-uid"},
+                stopped=mock_stopped,
+                patch=mock_patch_obj,
+                memo=MagicMock(),
+                logger=logging.getLogger("test"),
+            )
+
+            assert mock_patch_obj.status["phase"] == "Degraded"
+            assert "lacks permission" in mock_patch_obj.status["message"].lower()

--- a/tests/unit/test_client_secret_watcher.py
+++ b/tests/unit/test_client_secret_watcher.py
@@ -1,28 +1,20 @@
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from kubernetes.client.rest import ApiException
 
 from keycloak_operator.constants import ANNOTATION_RECONCILE_FORCE
-from keycloak_operator.handlers.client import monitor_client_secrets
+from keycloak_operator.handlers.client import (
+    _trigger_client_reconciliation,
+    monitor_client_credentials_secret,
+)
 
 
 @pytest.mark.asyncio
-async def test_monitor_client_secrets_deleted():
-    # Setup
-    event = {
-        "type": "DELETED",
-        "object": {
-            "metadata": {
-                "name": "my-secret",
-                "namespace": "my-ns",
-                "labels": {"vriesdemichael.github.io/keycloak-client": "my-client"},
-            }
-        },
-    }
+async def test_trigger_client_reconciliation_patches_client_resource():
     logger = MagicMock(spec=logging.Logger)
 
-    # Mock K8s API
     with (
         patch("keycloak_operator.handlers.client.get_kubernetes_client"),
         patch(
@@ -32,71 +24,106 @@ async def test_monitor_client_secrets_deleted():
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
-        # Execute
-        await monitor_client_secrets(event, logger)
-
-        # Verify
-        # Should call patch_namespaced_custom_object
-        assert mock_api.patch_namespaced_custom_object.called
-        call_args = mock_api.patch_namespaced_custom_object.call_args
-        args, kwargs = call_args
-
-        # Handle both keyword and positional argument patterns
-        if not kwargs and args:
-            # kubernetes.client.CustomObjectsApi.patch_namespaced_custom_object(
-            #     group, version, namespace, plural, name, body, **kwargs
-            # )
-            group, version, namespace, plural, name, body = args[:6]
-            call_params = {
-                "group": group,
-                "version": version,
-                "namespace": namespace,
-                "plural": plural,
-                "name": name,
-                "body": body,
-            }
-        else:
-            call_params = kwargs
-
-        # Verify patch arguments
-        assert call_params["group"] == "vriesdemichael.github.io"
-        assert call_params["version"] == "v1"
-        assert call_params["namespace"] == "my-ns"
-        assert call_params["plural"] == "keycloakclients"
-        assert call_params["name"] == "my-client"
-        assert (
-            ANNOTATION_RECONCILE_FORCE in call_params["body"]["metadata"]["annotations"]
+        triggered = await _trigger_client_reconciliation(
+            name="my-client",
+            namespace="my-ns",
+            reason="secret-missing",
+            logger=logger,
         )
+
+        assert triggered is True
+        assert mock_api.patch_namespaced_custom_object.called
+        _, kwargs = mock_api.patch_namespaced_custom_object.call_args
+        assert kwargs["group"] == "vriesdemichael.github.io"
+        assert kwargs["version"] == "v1"
+        assert kwargs["namespace"] == "my-ns"
+        assert kwargs["plural"] == "keycloakclients"
+        assert kwargs["name"] == "my-client"
+        assert ANNOTATION_RECONCILE_FORCE in kwargs["body"]["metadata"]["annotations"]
 
 
 @pytest.mark.asyncio
-async def test_monitor_client_secrets_ignored():
-    # Setup - Wrong event type
-    event = {
-        "type": "ADDED",
-        "object": {
-            "metadata": {
-                "name": "s",
-                "namespace": "n",
-                "labels": {"vriesdemichael.github.io/keycloak-client": "c"},
-            }
-        },
-    }
-    logger = MagicMock()
+async def test_monitor_client_credentials_secret_missing_triggers_reconcile():
+    logger = MagicMock(spec=logging.Logger)
+    patch_obj = MagicMock()
+    patch_obj.status = {}
+    stopped = MagicMock()
+    stopped.__bool__ = MagicMock(side_effect=[False, True])
+    stopped.wait = AsyncMock(return_value=True)
 
-    with patch(
-        "keycloak_operator.handlers.client.get_kubernetes_client"
-    ) as mock_get_client:
-        await monitor_client_secrets(event, logger)
-        assert not mock_get_client.called
+    with (
+        patch("keycloak_operator.handlers.client.get_kubernetes_client"),
+        patch(
+            "keycloak_operator.handlers.client.client.CoreV1Api"
+        ) as mock_core_api_cls,
+        patch(
+            "keycloak_operator.handlers.client.is_client_managed_by_this_operator",
+            return_value=True,
+        ),
+        patch(
+            "keycloak_operator.handlers.client._trigger_client_reconciliation",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_trigger,
+    ):
+        mock_core_api = MagicMock()
+        mock_core_api.read_namespaced_secret.side_effect = ApiException(status=404)
+        mock_core_api_cls.return_value = mock_core_api
 
-    # Setup - Missing label
-    event = {
-        "type": "DELETED",
-        "object": {"metadata": {"name": "s", "namespace": "n", "labels": {}}},
-    }
-    with patch(
-        "keycloak_operator.handlers.client.get_kubernetes_client"
-    ) as mock_get_client:
-        await monitor_client_secrets(event, logger)
-        assert not mock_get_client.called
+        await monitor_client_credentials_secret(
+            spec={"clientId": "test-client", "manageSecret": True},
+            name="test-client",
+            namespace="test-ns",
+            status={},
+            meta={},
+            stopped=stopped,
+            patch=patch_obj,
+            logger=logger,
+        )
+
+        mock_trigger.assert_awaited_once()
+        assert patch_obj.status["phase"] == "Degraded"
+        assert "recreating" in patch_obj.status["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_monitor_client_credentials_secret_forbidden_degrades_without_reconcile():
+    logger = MagicMock(spec=logging.Logger)
+    patch_obj = MagicMock()
+    patch_obj.status = {}
+    stopped = MagicMock()
+    stopped.__bool__ = MagicMock(side_effect=[False, True])
+    stopped.wait = AsyncMock(return_value=True)
+
+    with (
+        patch("keycloak_operator.handlers.client.get_kubernetes_client"),
+        patch(
+            "keycloak_operator.handlers.client.client.CoreV1Api"
+        ) as mock_core_api_cls,
+        patch(
+            "keycloak_operator.handlers.client.is_client_managed_by_this_operator",
+            return_value=True,
+        ),
+        patch(
+            "keycloak_operator.handlers.client._trigger_client_reconciliation",
+            new_callable=AsyncMock,
+        ) as mock_trigger,
+    ):
+        mock_core_api = MagicMock()
+        mock_core_api.read_namespaced_secret.side_effect = ApiException(status=403)
+        mock_core_api_cls.return_value = mock_core_api
+
+        await monitor_client_credentials_secret(
+            spec={"clientId": "test-client", "manageSecret": True},
+            name="test-client",
+            namespace="test-ns",
+            status={},
+            meta={},
+            stopped=stopped,
+            patch=patch_obj,
+            logger=logger,
+        )
+
+        mock_trigger.assert_not_awaited()
+        assert patch_obj.status["phase"] == "Degraded"
+        assert "lacks permission" in patch_obj.status["message"].lower()


### PR DESCRIPTION
## Summary
- replace the cluster-wide managed Secret watcher with per-KeycloakClient secret monitoring
- degrade cleanly when delegated RBAC does not allow reading a managed credentials Secret
- add unit and integration regressions for forbidden secret reads and RBAC removal recovery

## Testing
- uv run pytest tests/unit/test_client_secret_watcher.py tests/unit/test_client_secret_rotation.py tests/unit/test_health_daemon_structure.py -v
- uv run pytest tests/integration/test_client_secret_lifecycle.py -k secret_monitor_survives_missing_namespace_rbac -v

Closes #462