### PR TITLE
fix(operator): improve startup resilience for drift detection and client ownership

### DIFF
--- a/src/keycloak_operator/handlers/client.py
+++ b/src/keycloak_operator/handlers/client.py
@@ -87,6 +87,20 @@ async def _should_manage_client_or_retry(
             ),
             delay=10,
         )
+    if decision.should_fail:
+        realm_name = decision.realm_name or spec.get("realmRef", {}).get(
+            "name", "<unknown>"
+        )
+        realm_namespace = decision.realm_namespace or spec.get("realmRef", {}).get(
+            "namespace", namespace
+        )
+        raise kopf.PermanentError(
+            decision.message
+            or (
+                f"Cannot determine ownership for parent realm {realm_name} in namespace "
+                f"{realm_namespace} while reconciling KeycloakClient {name}"
+            )
+        )
 
     return decision.is_managed
 

--- a/src/keycloak_operator/handlers/client.py
+++ b/src/keycloak_operator/handlers/client.py
@@ -48,6 +48,7 @@ from keycloak_operator.services import KeycloakClientReconciler
 from keycloak_operator.settings import settings
 from keycloak_operator.utils.handler_logging import log_handler_entry
 from keycloak_operator.utils.isolation import (
+    get_client_management_decision,
     is_client_managed_by_this_operator,
 )
 from keycloak_operator.utils.keycloak_admin import get_keycloak_admin_client
@@ -61,6 +62,33 @@ logger = logging.getLogger(__name__)
 
 
 CLIENT_SECRET_MONITOR_INTERVAL_SECONDS = TIMER_INTERVAL_CLIENT
+
+
+async def _should_manage_client_or_retry(
+    spec: dict[str, Any],
+    name: str,
+    namespace: str,
+) -> bool:
+    """Return True when the client belongs to this operator, else retry if parent realm is missing."""
+    decision = await get_client_management_decision(
+        spec, namespace, get_kubernetes_client()
+    )
+    if decision.should_retry:
+        realm_name = decision.realm_name or spec.get("realmRef", {}).get(
+            "name", "<unknown>"
+        )
+        realm_namespace = decision.realm_namespace or spec.get("realmRef", {}).get(
+            "namespace", namespace
+        )
+        raise kopf.TemporaryError(
+            (
+                f"Waiting for parent realm {realm_name} in namespace "
+                f"{realm_namespace} before reconciling KeycloakClient {name}"
+            ),
+            delay=10,
+        )
+
+    return decision.is_managed
 
 
 def is_matching_namespace(spec: dict[str, Any], namespace: str, **_: Any) -> bool:
@@ -293,9 +321,7 @@ async def ensure_keycloak_client(
     log_handler_entry("create/resume", "keycloakclient", name, namespace)
 
     # Check ownership (ADR-062)
-    if not await is_client_managed_by_this_operator(
-        spec, namespace, get_kubernetes_client()
-    ):
+    if not await _should_manage_client_or_retry(spec, name, namespace):
         return None
 
     # Check if resource is being deleted - if so, skip reconciliation
@@ -383,9 +409,7 @@ async def update_keycloak_client(
     log_handler_entry("update", "keycloakclient", name, namespace)
 
     # Check ownership (ADR-062)
-    if not await is_client_managed_by_this_operator(
-        new.get("spec", {}), namespace, get_kubernetes_client()
-    ):
+    if not await _should_manage_client_or_retry(new.get("spec", {}), name, namespace):
         return None
 
     logger.info(f"Updating KeycloakClient {name} in namespace {namespace}")

--- a/src/keycloak_operator/operator.py
+++ b/src/keycloak_operator/operator.py
@@ -19,6 +19,7 @@ Environment Variables:
     KEYCLOAK_OPERATOR_DRY_RUN: Set to 'true' for dry-run mode
 """
 
+import asyncio
 import logging
 import random
 import sys
@@ -26,6 +27,7 @@ from urllib.parse import urlparse
 
 import kopf
 from kubernetes import config
+from kubernetes.client.rest import ApiException
 
 from keycloak_operator.constants import (
     OPERATOR_FINALIZER,
@@ -114,6 +116,35 @@ def _sanitize_url_for_log(url: str) -> str:
 
     port_suffix = f":{parsed.port}" if parsed.port is not None else ""
     return f"{parsed.scheme}://{hostname}{port_suffix}"
+
+
+async def _is_managed_keycloak_ready_for_drift_detection() -> tuple[bool, str]:
+    """Return whether drift detection may talk to the managed Keycloak instance."""
+    if not operator_settings.keycloak_managed:
+        return True, "external"
+
+    from kubernetes import client as k8s_client
+
+    from keycloak_operator.utils.kubernetes import get_kubernetes_client
+
+    custom_objects_api = k8s_client.CustomObjectsApi(get_kubernetes_client())
+
+    try:
+        keycloak = await asyncio.to_thread(
+            custom_objects_api.get_namespaced_custom_object,
+            group="vriesdemichael.github.io",
+            version="v1",
+            namespace=operator_settings.pod_namespace,
+            plural="keycloaks",
+            name="keycloak",
+        )
+    except ApiException as e:
+        if e.status == 404:
+            return False, "Missing"
+        raise
+
+    phase = str(keycloak.get("status", {}).get("phase", "Unknown"))
+    return phase in {"Ready", "Degraded"}, phase
 
 
 @kopf.on.startup()
@@ -321,6 +352,18 @@ async def drift_detection_timer(**kwargs) -> None:
         return  # Silently skip — no reconciliation means no point detecting drift
 
     logger = logging.getLogger(__name__)
+
+    (
+        keycloak_ready,
+        keycloak_phase,
+    ) = await _is_managed_keycloak_ready_for_drift_detection()
+    if not keycloak_ready:
+        logger.info(
+            "Skipping drift detection: managed Keycloak is not operational yet (phase=%s)",
+            keycloak_phase,
+        )
+        return
+
     logger.info("Starting periodic drift detection scan")
 
     try:

--- a/src/keycloak_operator/utils/isolation.py
+++ b/src/keycloak_operator/utils/isolation.py
@@ -9,11 +9,34 @@ the same cluster without interfering with each other.
 import asyncio
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any
+
+from kubernetes.client.rest import ApiException
 
 from keycloak_operator.settings import settings
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ClientManagementDecision:
+    """Outcome of resolving whether a client belongs to this operator."""
+
+    status: str
+    realm_name: str | None = None
+    realm_namespace: str | None = None
+    message: str | None = None
+
+    @property
+    def is_managed(self) -> bool:
+        """Return True when the client should be handled by this operator."""
+        return self.status == "managed"
+
+    @property
+    def should_retry(self) -> bool:
+        """Return True when ownership cannot be decided yet and should be retried."""
+        return self.status == "retry"
 
 
 def get_our_operator_namespace() -> str:
@@ -60,13 +83,13 @@ def is_managed_by_this_operator(spec: dict[str, Any], resource_namespace: str) -
     return resource_namespace in watch_list
 
 
-async def is_client_managed_by_this_operator(
+async def get_client_management_decision(
     spec: dict[str, Any],
     resource_namespace: str,
     k8s_client: Any,
-) -> bool:
+) -> ClientManagementDecision:
     """
-    Check if a KeycloakClient resource is managed by this operator instance.
+    Determine whether a KeycloakClient resource is managed by this operator.
 
     A client is managed by the operator that manages its parent realm.
 
@@ -76,7 +99,7 @@ async def is_client_managed_by_this_operator(
         k8s_client: Kubernetes API client
 
     Returns:
-        True if this operator instance should manage the client
+        Decision describing whether the client is managed or should be retried
     """
     from kubernetes import client as k8s_client_mod
 
@@ -86,7 +109,11 @@ async def is_client_managed_by_this_operator(
 
     if not realm_name:
         logger.warning(f"Client in {resource_namespace} is missing realmRef.name")
-        return False
+        return ClientManagementDecision(
+            status="not-managed",
+            realm_namespace=realm_namespace,
+            message="Client is missing realmRef.name",
+        )
 
     try:
         custom_objects_api = k8s_client_mod.CustomObjectsApi(k8s_client)
@@ -98,12 +125,60 @@ async def is_client_managed_by_this_operator(
             plural="keycloakrealms",
             name=realm_name,
         )
-        return is_managed_by_this_operator(realm.get("spec", {}), realm_namespace)
+        status = "managed"
+        if not is_managed_by_this_operator(realm.get("spec", {}), realm_namespace):
+            status = "not-managed"
+
+        return ClientManagementDecision(
+            status=status,
+            realm_name=realm_name,
+            realm_namespace=realm_namespace,
+        )
+    except ApiException as e:
+        if e.status == 404:
+            logger.debug(
+                "Parent realm '%s' in namespace '%s' not found yet for client in %s",
+                realm_name,
+                realm_namespace,
+                resource_namespace,
+            )
+            return ClientManagementDecision(
+                status="retry",
+                realm_name=realm_name,
+                realm_namespace=realm_namespace,
+                message="Parent realm not found yet",
+            )
+
+        logger.warning(
+            f"Could not determine ownership for client in {resource_namespace}: "
+            f"parent realm '{realm_name}' in '{realm_namespace}' lookup failed: {e}"
+        )
+        return ClientManagementDecision(
+            status="retry",
+            realm_name=realm_name,
+            realm_namespace=realm_namespace,
+            message=str(e),
+        )
     except Exception as e:
         logger.warning(
             f"Could not determine ownership for client in {resource_namespace}: "
             f"parent realm '{realm_name}' in '{realm_namespace}' lookup failed: {e}"
         )
-        # If the realm is missing, we can't claim ownership.
-        # Returning False ensures we don't touch the status of an orphan we don't own.
-        return False
+        return ClientManagementDecision(
+            status="retry",
+            realm_name=realm_name,
+            realm_namespace=realm_namespace,
+            message=str(e),
+        )
+
+
+async def is_client_managed_by_this_operator(
+    spec: dict[str, Any],
+    resource_namespace: str,
+    k8s_client: Any,
+) -> bool:
+    """Check if a KeycloakClient resource is managed by this operator instance."""
+    decision = await get_client_management_decision(
+        spec, resource_namespace, k8s_client
+    )
+    return decision.is_managed

--- a/src/keycloak_operator/utils/isolation.py
+++ b/src/keycloak_operator/utils/isolation.py
@@ -19,6 +19,16 @@ from keycloak_operator.settings import settings
 logger = logging.getLogger(__name__)
 
 
+def _is_retryable_client_lookup_error(error: ApiException) -> bool:
+    """Return whether a realm lookup error should be retried."""
+    status = error.status
+    if status == 404:
+        return True
+    if status in {409, 429}:
+        return True
+    return isinstance(status, int) and status >= 500
+
+
 @dataclass(frozen=True)
 class ClientManagementDecision:
     """Outcome of resolving whether a client belongs to this operator."""
@@ -37,6 +47,11 @@ class ClientManagementDecision:
     def should_retry(self) -> bool:
         """Return True when ownership cannot be decided yet and should be retried."""
         return self.status == "retry"
+
+    @property
+    def should_fail(self) -> bool:
+        """Return True when ownership resolution hit a permanent error."""
+        return self.status == "error"
 
 
 def get_our_operator_namespace() -> str:
@@ -149,12 +164,24 @@ async def get_client_management_decision(
                 message="Parent realm not found yet",
             )
 
-        logger.warning(
-            f"Could not determine ownership for client in {resource_namespace}: "
-            f"parent realm '{realm_name}' in '{realm_namespace}' lookup failed: {e}"
+        if _is_retryable_client_lookup_error(e):
+            logger.warning(
+                f"Could not determine ownership for client in {resource_namespace}: "
+                f"parent realm '{realm_name}' in '{realm_namespace}' lookup failed: {e}"
+            )
+            return ClientManagementDecision(
+                status="retry",
+                realm_name=realm_name,
+                realm_namespace=realm_namespace,
+                message=str(e),
+            )
+
+        logger.error(
+            f"Cannot determine ownership for client in {resource_namespace}: "
+            f"parent realm '{realm_name}' in '{realm_namespace}' lookup failed permanently: {e}"
         )
         return ClientManagementDecision(
-            status="retry",
+            status="error",
             realm_name=realm_name,
             realm_namespace=realm_namespace,
             message=str(e),

--- a/tests/unit/test_handler_pause.py
+++ b/tests/unit/test_handler_pause.py
@@ -306,9 +306,9 @@ class TestClientHandlerPause:
                 return_value=pause_msg,
             ),
             patch(
-                "keycloak_operator.handlers.client.is_client_managed_by_this_operator",
+                "keycloak_operator.handlers.client.get_client_management_decision",
                 new_callable=AsyncMock,
-                return_value=True,
+                return_value=MagicMock(is_managed=True, should_retry=False),
             ),
             patch("keycloak_operator.handlers.client.get_kubernetes_client"),
             patch(
@@ -355,9 +355,9 @@ class TestClientHandlerPause:
                 return_value=pause_msg,
             ),
             patch(
-                "keycloak_operator.handlers.client.is_client_managed_by_this_operator",
+                "keycloak_operator.handlers.client.get_client_management_decision",
                 new_callable=AsyncMock,
-                return_value=True,
+                return_value=MagicMock(is_managed=True, should_retry=False),
             ),
             patch("keycloak_operator.handlers.client.get_kubernetes_client"),
             patch(
@@ -464,6 +464,14 @@ class TestDriftDetectionPause:
                 return_value=True,
             ),
             patch(
+                "keycloak_operator.operator._is_managed_keycloak_ready_for_drift_detection",
+                new=AsyncMock(return_value=(True, "Ready")),
+            ),
+            patch(
+                "keycloak_operator.operator._is_managed_keycloak_ready_for_drift_detection",
+                new=AsyncMock(return_value=(True, "Ready")),
+            ),
+            patch(
                 "keycloak_operator.services.drift_detection_service.DriftDetectionConfig.from_env",
             ) as mock_config,
             patch(
@@ -491,6 +499,10 @@ class TestDriftDetectionPause:
             patch(
                 "keycloak_operator.utils.pause.is_clients_paused",
                 return_value=False,
+            ),
+            patch(
+                "keycloak_operator.operator._is_managed_keycloak_ready_for_drift_detection",
+                new=AsyncMock(return_value=(True, "Ready")),
             ),
             patch(
                 "keycloak_operator.services.drift_detection_service.DriftDetectionConfig.from_env",

--- a/tests/unit/test_handler_pause.py
+++ b/tests/unit/test_handler_pause.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from keycloak_operator.utils.isolation import ClientManagementDecision
+
 
 class TestKeycloakHandlerPause:
     """Test pause wiring in keycloak.py create/resume and update handlers."""
@@ -308,7 +310,7 @@ class TestClientHandlerPause:
             patch(
                 "keycloak_operator.handlers.client.get_client_management_decision",
                 new_callable=AsyncMock,
-                return_value=MagicMock(is_managed=True, should_retry=False),
+                return_value=ClientManagementDecision(status="managed"),
             ),
             patch("keycloak_operator.handlers.client.get_kubernetes_client"),
             patch(
@@ -357,7 +359,7 @@ class TestClientHandlerPause:
             patch(
                 "keycloak_operator.handlers.client.get_client_management_decision",
                 new_callable=AsyncMock,
-                return_value=MagicMock(is_managed=True, should_retry=False),
+                return_value=ClientManagementDecision(status="managed"),
             ),
             patch("keycloak_operator.handlers.client.get_kubernetes_client"),
             patch(
@@ -462,10 +464,6 @@ class TestDriftDetectionPause:
             patch(
                 "keycloak_operator.utils.pause.is_clients_paused",
                 return_value=True,
-            ),
-            patch(
-                "keycloak_operator.operator._is_managed_keycloak_ready_for_drift_detection",
-                new=AsyncMock(return_value=(True, "Ready")),
             ),
             patch(
                 "keycloak_operator.operator._is_managed_keycloak_ready_for_drift_detection",

--- a/tests/unit/test_startup_resilience.py
+++ b/tests/unit/test_startup_resilience.py
@@ -146,6 +146,46 @@ class TestClientOwnershipDecisions:
         assert decision.is_managed is False
 
     @pytest.mark.asyncio
+    async def test_parent_realm_lookup_forbidden_returns_error_decision(self):
+        """Permanent realm lookup failures should not hot-loop retries."""
+        mock_custom_api = MagicMock()
+        mock_custom_api.get_namespaced_custom_object.side_effect = ApiException(
+            status=403,
+            reason="Forbidden",
+        )
+
+        with patch("kubernetes.client.CustomObjectsApi", return_value=mock_custom_api):
+            decision = await get_client_management_decision(
+                self._client_spec(),
+                "client-ns",
+                MagicMock(),
+            )
+
+        assert decision.should_retry is False
+        assert decision.should_fail is True
+        assert decision.is_managed is False
+
+    @pytest.mark.asyncio
+    async def test_parent_realm_lookup_server_error_returns_retry_decision(self):
+        """Transient realm lookup failures should still be retried."""
+        mock_custom_api = MagicMock()
+        mock_custom_api.get_namespaced_custom_object.side_effect = ApiException(
+            status=500,
+            reason="Internal Server Error",
+        )
+
+        with patch("kubernetes.client.CustomObjectsApi", return_value=mock_custom_api):
+            decision = await get_client_management_decision(
+                self._client_spec(),
+                "client-ns",
+                MagicMock(),
+            )
+
+        assert decision.should_retry is True
+        assert decision.should_fail is False
+        assert decision.is_managed is False
+
+    @pytest.mark.asyncio
     async def test_ensure_client_retries_when_parent_realm_missing(self):
         """Create/resume handler should requeue until the parent realm exists."""
         from keycloak_operator.handlers.client import ensure_keycloak_client
@@ -198,6 +238,76 @@ class TestClientOwnershipDecisions:
             ),
         ):
             with pytest.raises(kopf.TemporaryError, match="Waiting for parent realm"):
+                await update_keycloak_client(
+                    old={"spec": self._client_spec()},
+                    new={"spec": self._client_spec()},
+                    diff=[],
+                    name="test-client",
+                    namespace="client-ns",
+                    status={},
+                    patch=MagicMock(status={}),
+                    memo=MagicMock(rate_limiter=MagicMock()),
+                )
+
+    @pytest.mark.asyncio
+    async def test_ensure_client_fails_when_parent_realm_lookup_is_permanent_error(
+        self,
+    ):
+        """Create/resume handler should fail fast on permanent ownership errors."""
+        from keycloak_operator.handlers.client import ensure_keycloak_client
+
+        with (
+            patch(
+                "keycloak_operator.handlers.client.get_client_management_decision",
+                new=AsyncMock(
+                    return_value=ClientManagementDecision(
+                        status="error",
+                        realm_name="test-realm",
+                        realm_namespace="realm-ns",
+                        message="403 Forbidden",
+                    )
+                ),
+            ),
+            patch(
+                "keycloak_operator.handlers.client.get_kubernetes_client",
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(kopf.PermanentError, match="403 Forbidden"):
+                await ensure_keycloak_client(
+                    spec=self._client_spec(),
+                    name="test-client",
+                    namespace="client-ns",
+                    status={},
+                    patch=MagicMock(status={}),
+                    memo=MagicMock(rate_limiter=MagicMock()),
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_client_fails_when_parent_realm_lookup_is_permanent_error(
+        self,
+    ):
+        """Update handler should fail fast on permanent ownership errors."""
+        from keycloak_operator.handlers.client import update_keycloak_client
+
+        with (
+            patch(
+                "keycloak_operator.handlers.client.get_client_management_decision",
+                new=AsyncMock(
+                    return_value=ClientManagementDecision(
+                        status="error",
+                        realm_name="test-realm",
+                        realm_namespace="realm-ns",
+                        message="403 Forbidden",
+                    )
+                ),
+            ),
+            patch(
+                "keycloak_operator.handlers.client.get_kubernetes_client",
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(kopf.PermanentError, match="403 Forbidden"):
                 await update_keycloak_client(
                     old={"spec": self._client_spec()},
                     new={"spec": self._client_spec()},

--- a/tests/unit/test_startup_resilience.py
+++ b/tests/unit/test_startup_resilience.py
@@ -1,0 +1,210 @@
+"""Unit tests for startup race handling and resilience helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import kopf
+import pytest
+from kubernetes.client.rest import ApiException
+
+from keycloak_operator.utils.isolation import (
+    ClientManagementDecision,
+    get_client_management_decision,
+)
+
+
+class TestDriftDetectionReadiness:
+    """Tests for managed-mode drift detection startup gating."""
+
+    @pytest.mark.asyncio
+    async def test_managed_keycloak_readiness_skips_external_mode(self):
+        """External mode should not require a managed Keycloak CR."""
+        from keycloak_operator.operator import (
+            _is_managed_keycloak_ready_for_drift_detection,
+            operator_settings,
+        )
+
+        with (
+            patch.object(operator_settings, "keycloak_managed", False),
+            patch("kubernetes.client.CustomObjectsApi") as mock_custom_objects,
+        ):
+            ready, phase = await _is_managed_keycloak_ready_for_drift_detection()
+
+        assert ready is True
+        assert phase == "external"
+        mock_custom_objects.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_managed_keycloak_readiness_returns_false_for_non_ready_phase(self):
+        """Managed mode should skip drift detection until the Keycloak CR is operational."""
+        from keycloak_operator.operator import (
+            _is_managed_keycloak_ready_for_drift_detection,
+            operator_settings,
+        )
+
+        mock_custom_api = MagicMock()
+        mock_custom_api.get_namespaced_custom_object.return_value = {
+            "status": {"phase": "Provisioning"}
+        }
+
+        with (
+            patch.object(operator_settings, "keycloak_managed", True),
+            patch.object(operator_settings, "pod_namespace", "keycloak-system"),
+            patch("kubernetes.client.CustomObjectsApi", return_value=mock_custom_api),
+            patch(
+                "keycloak_operator.utils.kubernetes.get_kubernetes_client",
+                return_value=MagicMock(),
+            ),
+        ):
+            ready, phase = await _is_managed_keycloak_ready_for_drift_detection()
+
+        assert ready is False
+        assert phase == "Provisioning"
+
+    @pytest.mark.asyncio
+    async def test_drift_detection_timer_skips_until_managed_keycloak_ready(self):
+        """The timer should not instantiate the detector before Keycloak is operational."""
+        from keycloak_operator.operator import drift_detection_timer
+
+        with (
+            patch(
+                "keycloak_operator.utils.pause.is_realms_paused",
+                return_value=False,
+            ),
+            patch(
+                "keycloak_operator.utils.pause.is_clients_paused",
+                return_value=False,
+            ),
+            patch(
+                "keycloak_operator.operator._is_managed_keycloak_ready_for_drift_detection",
+                new=AsyncMock(return_value=(False, "Provisioning")),
+            ),
+            patch(
+                "keycloak_operator.services.drift_detection_service.DriftDetectionConfig.from_env",
+            ) as mock_config,
+            patch(
+                "keycloak_operator.services.drift_detection_service.DriftDetector",
+            ) as mock_detector_cls,
+        ):
+            mock_config.return_value.enabled = True
+
+            await drift_detection_timer()
+
+        mock_detector_cls.assert_not_called()
+
+
+class TestClientOwnershipDecisions:
+    """Tests for retry-aware client ownership resolution."""
+
+    @staticmethod
+    def _client_spec() -> dict[str, object]:
+        return {
+            "clientId": "test-client",
+            "realmRef": {"name": "test-realm", "namespace": "realm-ns"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_parent_realm_returns_retry_decision(self):
+        """A missing parent realm should be treated as a transient startup condition."""
+        mock_custom_api = MagicMock()
+        mock_custom_api.get_namespaced_custom_object.side_effect = ApiException(
+            status=404,
+            reason="Not Found",
+        )
+
+        with patch("kubernetes.client.CustomObjectsApi", return_value=mock_custom_api):
+            decision = await get_client_management_decision(
+                self._client_spec(),
+                "client-ns",
+                MagicMock(),
+            )
+
+        assert decision.should_retry is True
+        assert decision.is_managed is False
+        assert decision.realm_name == "test-realm"
+        assert decision.realm_namespace == "realm-ns"
+
+    @pytest.mark.asyncio
+    async def test_parent_realm_owned_by_other_operator_is_not_managed(self):
+        """Ownership mismatch should not be retried."""
+        mock_custom_api = MagicMock()
+        mock_custom_api.get_namespaced_custom_object.return_value = {"spec": {}}
+
+        with (
+            patch("kubernetes.client.CustomObjectsApi", return_value=mock_custom_api),
+            patch(
+                "keycloak_operator.utils.isolation.is_managed_by_this_operator",
+                return_value=False,
+            ),
+        ):
+            decision = await get_client_management_decision(
+                self._client_spec(),
+                "client-ns",
+                MagicMock(),
+            )
+
+        assert decision.should_retry is False
+        assert decision.is_managed is False
+
+    @pytest.mark.asyncio
+    async def test_ensure_client_retries_when_parent_realm_missing(self):
+        """Create/resume handler should requeue until the parent realm exists."""
+        from keycloak_operator.handlers.client import ensure_keycloak_client
+
+        with (
+            patch(
+                "keycloak_operator.handlers.client.get_client_management_decision",
+                new=AsyncMock(
+                    return_value=ClientManagementDecision(
+                        status="retry",
+                        realm_name="test-realm",
+                        realm_namespace="realm-ns",
+                    )
+                ),
+            ),
+            patch(
+                "keycloak_operator.handlers.client.get_kubernetes_client",
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(kopf.TemporaryError, match="Waiting for parent realm"):
+                await ensure_keycloak_client(
+                    spec=self._client_spec(),
+                    name="test-client",
+                    namespace="client-ns",
+                    status={},
+                    patch=MagicMock(status={}),
+                    memo=MagicMock(rate_limiter=MagicMock()),
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_client_retries_when_parent_realm_missing(self):
+        """Update handler should requeue until the parent realm exists."""
+        from keycloak_operator.handlers.client import update_keycloak_client
+
+        with (
+            patch(
+                "keycloak_operator.handlers.client.get_client_management_decision",
+                new=AsyncMock(
+                    return_value=ClientManagementDecision(
+                        status="retry",
+                        realm_name="test-realm",
+                        realm_namespace="realm-ns",
+                    )
+                ),
+            ),
+            patch(
+                "keycloak_operator.handlers.client.get_kubernetes_client",
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(kopf.TemporaryError, match="Waiting for parent realm"):
+                await update_keycloak_client(
+                    old={"spec": self._client_spec()},
+                    new={"spec": self._client_spec()},
+                    diff=[],
+                    name="test-client",
+                    namespace="client-ns",
+                    status={},
+                    patch=MagicMock(status={}),
+                    memo=MagicMock(rate_limiter=MagicMock()),
+                )


### PR DESCRIPTION
## Summary
- skip managed-mode drift detection cycles until the Keycloak CR is operational
- requeue KeycloakClient create and update when the parent realm is not present yet
- add focused unit coverage for the new startup resilience paths

Fixes #777

## Validation
- task quality:check
- task test:unit
- task test:all