### PR TITLE
chore: ignore Python pre-release Docker image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,13 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      # Ignore Python pre-release builds (alpha, beta, rc).
+      # Dependabot has no native "stable-only" filter for Docker images, so
+      # we explicitly block the 3.15.x pre-release series here.
+      # REMOVE this rule once python:3.15.0-alpine3.23 stable is published.
+      - dependency-name: "python"
+        versions: [">= 3.15.0.pre, < 3.15.0"]
 
   - package-ecosystem: "gomod"
     directory: "/tools/migration-toolkit"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,12 +88,23 @@ updates:
       - "dependencies"
       - "docker"
     ignore:
-      # Ignore Python pre-release builds (alpha, beta, rc).
-      # Dependabot has no native "stable-only" filter for Docker images, so
-      # we explicitly block the 3.15.x pre-release series here.
-      # REMOVE this rule once python:3.15.0-alpine3.23 stable is published.
+      # Ignore Python pre-release builds (alpha, beta, rc) for upcoming versions.
+      # Dependabot has no native "stable-only" filter for Docker images, so we use
+      # Bundler version-range syntax. In Gem::Version semantics, string segments
+      # (a, b, rc) compare as LESS than numeric ones, so all pre-releases of a
+      # version are < the stable release:
+      #   3.15.0a6  -> segments [3,15,0,"a",6]  < [3,15,0] (3.15.0 stable)
+      #   3.15.0b1  -> segments [3,15,0,"b",1]  < [3,15,0]
+      #   3.15.0rc1 -> segments [3,15,0,"rc",1] < [3,15,0]
+      # The lower bound ">= 3.x.0.a" equals [3,x,0,"a"] which is <= every real
+      # alpha tag (3.x.0a1 == [3,x,0,"a",1] >= [3,x,0,"a",0]).
+      # NOTE: remove a version's entry once python:3.x.0-alpineY stable is published.
       - dependency-name: "python"
-        versions: [">= 3.15.0.pre, < 3.15.0"]
+        versions:
+          - ">= 3.15.0.a, < 3.15.0"  # 3.15 pre-releases — remove when 3.15.0 stable ships
+          - ">= 3.16.0.a, < 3.16.0"  # 3.16 pre-releases — remove when 3.16.0 stable ships
+          - ">= 3.17.0.a, < 3.17.0"  # 3.17 pre-releases — remove when 3.17.0 stable ships
+          - ">= 3.18.0.a, < 3.18.0"  # 3.18 pre-releases — remove when 3.18.0 stable ships
 
   - package-ecosystem: "gomod"
     directory: "/tools/migration-toolkit"


### PR DESCRIPTION
## Problem

Dependabot automatically opened a PR to bump the operator base image from `python:3.14.4-alpine3.23` to `python:3.15.0b1-alpine3.23` (beta). This happened because `3.15.0b1` was the newest available Python Alpine tag at the time — `3.14.5` hadn't been published yet.

Dependabot has no native "stable-only" filter for Docker images, so it happily proposes pre-release builds.

## Fix

Add an `ignore` rule for the `3.15.x` pre-release series (`>= 3.15.0.pre, < 3.15.0`) using Bundler version syntax (the format Dependabot uses for Docker version ranges).

This covers all alpha (`a`), beta (`b`), and release candidate (`rc`) builds of 3.15.

## What to do when Python 3.15.0 stable ships

Remove the `ignore` block from the Docker `/images/operator` section of `.github/dependabot.yml`. Dependabot will then pick up the stable release on its next run.

## Note on PR 839

PR #839 (`python:3.15.0b1-alpine3.23`) was closed as a pre-release bump. In the meantime `3.14.5` (a patch release) was merged to main and is the current stable base.