### PR TITLE
fix(chart-operator): update for operator v0.10.23

### DIFF
--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: keycloak-operator
 description: A Helm chart for deploying the Keycloak Operator with GitOps compatibility
 type: application
 version: 0.7.20
-appVersion: "v0.10.22"
+appVersion: "v0.10.23"
 keywords:
   - keycloak
   - operator

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -37,7 +37,7 @@ operator:
     # Overrides the image tag whose default is the chart appVersion.
     # This is automatically updated by the update-chart-versions workflow on new releases
     # Example: "v0.3.2" or "latest"
-    tag: "v0.10.22"
+    tag: "v0.10.23"
   # Image pull secrets for private registries
   # Example:
   # imagePullSecrets:


### PR DESCRIPTION
Updates operator chart to use operator version `v0.10.23`.

**Changes:**
- Updated `charts/keycloak-operator/values.yaml` image tag
- Updated `charts/keycloak-operator/Chart.yaml` appVersion

This fix ensures the chart is compatible with operator v0.10.23.

🤖 Auto-generated by CI/CD workflow