### PR TITLE
fix: harden pause-client test against Kopf cold-start watch race

### DIFF
--- a/src/keycloak_operator/operator.py
+++ b/src/keycloak_operator/operator.py
@@ -147,6 +147,35 @@ async def _is_managed_keycloak_ready_for_drift_detection() -> tuple[bool, str]:
     return phase in {"Ready", "Degraded"}, phase
 
 
+# Watch-readiness gate (ADR: cold-start event delivery).
+#
+# Declaring at least one @kopf.index per watched CRD kind makes Kopf block ALL
+# cause handlers until every indexed kind has finished its initial listing
+# (Kopf awaits the global ``operator_indexed`` toggle once, on cold start, then
+# drops the gate). Without an index, each resource's watch is independent: a
+# freshly-deployed operator can deliver an event for one kind (e.g. a realm)
+# while another kind's watch (e.g. clients) is still mid-listing, so a CR
+# created in that window has its create event dropped and never reconciles.
+#
+# These indexes intentionally store nothing (returning None discards the value);
+# they exist solely to couple the watches into a single readiness gate so that,
+# once the operator handles ANY resource, every CRD watch is provably streaming.
+_WATCH_READINESS_GROUP = "vriesdemichael.github.io"
+_WATCH_READINESS_VERSION = "v1"
+
+
+@kopf.index("keycloaks", group=_WATCH_READINESS_GROUP, version=_WATCH_READINESS_VERSION)
+@kopf.index(
+    "keycloakrealms", group=_WATCH_READINESS_GROUP, version=_WATCH_READINESS_VERSION
+)
+@kopf.index(
+    "keycloakclients", group=_WATCH_READINESS_GROUP, version=_WATCH_READINESS_VERSION
+)
+def watch_readiness_index(**_) -> None:
+    """No-op index used only to gate handlers on initial-listing completion."""
+    return None
+
+
 @kopf.on.startup()
 async def startup_handler(
     settings: kopf.OperatorSettings, memo: kopf.Memo, **_

--- a/tests/integration/test_reconciliation_pause.py
+++ b/tests/integration/test_reconciliation_pause.py
@@ -30,6 +30,7 @@ from keycloak_operator.models.realm import KeycloakRealmSpec, OperatorRef
 from tests.integration.conftest import build_client_manifest, build_realm_manifest
 from tests.integration.wait_helpers import (
     wait_for_resource_condition,
+    wait_for_resource_condition_with_retrigger,
     wait_for_resource_deleted,
 )
 
@@ -733,12 +734,13 @@ class TestReconciliationPauseClients:
                 body=client_manifest,
             )
 
-            # Wait for Paused phase.
-            # 180s timeout: the operator may be under load after reconciling the
-            # realm and deploying with fresh jitter.  The key-ordering fix in
-            # _add_condition removes the Kopf requeue loop, but extra headroom
-            # guards against general CI runner stress.
-            resource = await wait_for_resource_condition(
+            # Wait for Paused phase, re-emitting the event if the freshly-deployed
+            # operator missed the client's initial create event (Kopf cold-start
+            # watch race). The @kopf.index watch-readiness gate makes this rare,
+            # but the retrigger self-heals a mid-run watch reconnect too. The
+            # re-emit only fires while the CR has no status, so a delivered event
+            # is never triggered twice.
+            resource = await wait_for_resource_condition_with_retrigger(
                 k8s_custom_objects=k8s_custom_objects,
                 group="vriesdemichael.github.io",
                 version="v1",
@@ -750,6 +752,7 @@ class TestReconciliationPauseClients:
                 ),
                 expected_phases=("Paused",),
                 timeout=180,
+                grace=45,
                 operator_namespace=test_namespace,
             )
 

--- a/tests/integration/wait_helpers.py
+++ b/tests/integration/wait_helpers.py
@@ -15,6 +15,7 @@ import logging
 import subprocess
 import tempfile
 from collections.abc import Callable
+from datetime import UTC, datetime
 from typing import Any
 
 from kubernetes.client.rest import ApiException
@@ -272,6 +273,117 @@ async def wait_for_resource_condition(
     error_message = "\n".join(error_parts)
 
     raise ResourceNotReadyError(error_message)
+
+
+async def wait_for_resource_condition_with_retrigger(
+    k8s_custom_objects,
+    group: str,
+    version: str,
+    namespace: str,
+    plural: str,
+    name: str,
+    condition_func: Callable[[dict[str, Any]], bool],
+    *,
+    timeout: int = 180,
+    grace: int = 45,
+    interval: int = 3,
+    operator_namespace: str | None = None,
+    expected_phases: tuple[str, ...] = ("Ready", "Degraded"),
+    retrigger_annotation: str = "test.vriesdemichael.github.io/retrigger",
+) -> dict[str, Any]:
+    """Wait for a condition, re-emitting an event if the CR is never picked up.
+
+    This guards against the Kopf cold-start race where a freshly-deployed
+    operator misses the initial create event for a resource (the CR then sits
+    with no status forever). If the condition is not met within ``grace``
+    seconds, we re-emit an event by patching a benign annotation, then keep
+    waiting — bounded by the overall ``timeout``.
+
+    Double-emit guard: the re-trigger only fires when the resource still has NO
+    status. If a status is already present, the operator HAS reacted to the
+    original event, so we must not patch in a duplicate trigger — we simply
+    keep waiting for the condition.
+
+    Args mirror ``wait_for_resource_condition``; ``grace`` is how long to wait
+    for the operator to react before assuming the initial event was missed.
+
+    Raises:
+        ResourceNotReadyError: When the overall timeout is reached.
+    """
+    import time
+
+    deadline = time.time() + timeout
+
+    while True:
+        remaining = int(deadline - time.time())
+        if remaining <= 0:
+            # Out of budget: one last short wait so the failure carries the full
+            # debugging context (operator logs/events) from the base helper.
+            return await wait_for_resource_condition(
+                k8s_custom_objects=k8s_custom_objects,
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                name=name,
+                condition_func=condition_func,
+                timeout=interval,
+                interval=interval,
+                operator_namespace=operator_namespace,
+                expected_phases=expected_phases,
+            )
+
+        try:
+            return await wait_for_resource_condition(
+                k8s_custom_objects=k8s_custom_objects,
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                name=name,
+                condition_func=condition_func,
+                timeout=min(grace, remaining),
+                interval=interval,
+                operator_namespace=operator_namespace,
+                expected_phases=expected_phases,
+            )
+        except ResourceNotReadyError:
+            # Guard against a duplicate trigger: only re-emit if the operator has
+            # genuinely not reacted yet (no status at all). A non-empty status
+            # means the original event WAS delivered; keep waiting instead.
+            status = await _get_resource_status(
+                k8s_custom_objects, group, version, namespace, plural, name
+            )
+            if status:
+                continue
+
+            try:
+                await k8s_custom_objects.patch_namespaced_custom_object(
+                    group=group,
+                    version=version,
+                    namespace=namespace,
+                    plural=plural,
+                    name=name,
+                    body={
+                        "metadata": {
+                            "annotations": {
+                                retrigger_annotation: datetime.now(UTC).isoformat()
+                            }
+                        }
+                    },
+                )
+                logger.warning(
+                    "Re-emitted event for %s/%s in %s: no status after %ss, "
+                    "operator likely missed the initial watch event.",
+                    plural,
+                    name,
+                    namespace,
+                    grace,
+                )
+            except ApiException as exc:
+                if exc.status != 404:
+                    raise
+                # Resource is gone; let the next loop iteration surface it.
 
 
 async def wait_for_resource_ready(


### PR DESCRIPTION
Fixes the residual flake in `test_client_gets_paused_status` (seen again on the release PR after the `observedGeneration` fix merged). All tests pass; the client CR intermittently never reconciled — the operator's client **create** handler was never invoked, so the CR sat with no status until the 180s timeout.

## Root cause
The operator declares **no `@kopf.index`**, so each CRD kind's watch is independent. On a freshly-deployed operator (the pause tests deploy a dedicated operator per test), the realm watch could deliver an event — realm reaches `Paused` — while the `keycloakclients` watch was still completing its initial listing. A client created in that window had its create event dropped entirely. Confirmed from the full operator log: only the client *delete* handler ever fired (during cleanup); no create handler, and no kopf `inconsistencies` warning (the earlier CRD fix holds).

## Fix (A + C)

**A — Watch-readiness gate (operator).** Declare a no-op `@kopf.index` for all three CRD kinds. Kopf then blocks every cause handler until the global `operator_indexed` toggle is on — i.e. *all* indexed kinds have finished their initial listing (verified in `kopf/_core/reactor/processing.py`: `await operator_indexed.wait_for(True)`). It's a one-time cold-start gate. Once the operator handles *any* resource, every CRD watch is provably streaming, so the test's "wait for realm `Paused` before creating the client" becomes a real readiness guarantee. This also hardens production cold starts (no half-initialized reconciliation).

**C — Guarded re-emit (test).** `wait_for_resource_condition_with_retrigger`: if the CR isn't picked up within a grace window, re-emit an event by patching a benign annotation, bounded by the overall timeout — self-healing a mid-run watch reconnect that (A) can't cover. **Double-emit guard:** the re-trigger only fires while the CR still has *no status*; if a status is already present the original event was delivered, so we keep waiting instead of triggering twice.

## Why not the readiness probe
`/ready` can't be made watch-aware for *empty* resource kinds: Kopf pre-creates index ids (so `id in indices` is always true) and exposes no initial-listing-complete signal to probes. The gate is therefore enforced via the indexing mechanism, not the probe.

## Validation
- `ruff` + `ty` clean; 346 relevant unit tests pass.
- The integration behaviour needs a real cluster (CI) to confirm — I can't reproduce the kopf watch timing locally.

This is a test-harness/framework-timing hardening, not a pause-feature change — the pause logic itself is correct and only ran when the handler was actually invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)